### PR TITLE
Changes to upgrade of v1 => v2

### DIFF
--- a/contracts/ZeroDAOToken.sol
+++ b/contracts/ZeroDAOToken.sol
@@ -21,10 +21,10 @@ contract ZeroDAOToken is
   // Mapping which stores all addresses allowed to snapshot
   mapping(address => bool) authorizedToSnapshot;
 
-  function initialize(string memory name, string memory symbol)
-    public
-    initializer
-  {
+  function initialize(
+    string memory name,
+    string memory symbol
+  ) public initializer {
     __Ownable_init();
     __ERC20_init(name, symbol);
     __ERC20Snapshot_init();
@@ -114,10 +114,10 @@ contract ZeroDAOToken is
    * @param amount The amount of tokens to send
    * @return Boolean if the transfer was a success
    */
-  function transferBulk(address[] calldata recipients, uint256 amount)
-    external
-    returns (bool)
-  {
+  function transferBulk(
+    address[] calldata recipients,
+    uint256 amount
+  ) external returns (bool) {
     address sender = _msgSender();
 
     uint256 total = amount * recipients.length;

--- a/contracts/ZeroDAOTokenV2.sol
+++ b/contracts/ZeroDAOTokenV2.sol
@@ -115,10 +115,7 @@ contract ZeroDAOTokenV2 is
       address(token) != address(0),
       "zDAOToken: Token address cannot be zero"
     );
-    require(
-      address(token) != address(this),
-      "zDAOToken: Token address cannot be this token"
-    );
+
     require(to != address(0), "zDAOToken: Recipient address cannot be zero");
 
     uint256 withdrawAmount;
@@ -126,7 +123,6 @@ contract ZeroDAOTokenV2 is
       // If amount is 0, withdraw all available tokens
       withdrawAmount = token.balanceOf(address(this));
     } else {
-      // Otherwise, ensure the requested amount doesn't exceed the contract's balance
       withdrawAmount = amount;
     }
 

--- a/contracts/ZeroDAOTokenV2.sol
+++ b/contracts/ZeroDAOTokenV2.sol
@@ -12,8 +12,6 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import {console} from "hardhat/console.sol";
-
 contract ZeroDAOTokenV2 is
   OwnableUpgradeable,
   ERC20Upgradeable,

--- a/contracts/ZeroDAOTokenV2.sol
+++ b/contracts/ZeroDAOTokenV2.sol
@@ -12,6 +12,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+import {console} from "hardhat/console.sol";
+
 contract ZeroDAOTokenV2 is
   OwnableUpgradeable,
   ERC20Upgradeable,
@@ -244,10 +246,10 @@ contract ZeroDAOTokenV2 is
     address to,
     uint256 amount
   ) internal override {
-    super._transfer(from, to, amount);
-
     if (to == address(this)) {
       _burn(from, amount);
+    } else {
+      super._transfer(from, to, amount);
     }
   }
 }

--- a/contracts/ZeroDAOTokenV2.sol
+++ b/contracts/ZeroDAOTokenV2.sol
@@ -48,24 +48,6 @@ contract ZeroDAOTokenV2 is
   }
 
   /**
-   * Mints new tokens.
-   * @param account the account to mint the tokens for
-   * @param amount the amount of tokens to mint.
-   */
-  function mint(address account, uint256 amount) external onlyOwner {
-    _mint(account, amount);
-  }
-
-  /**
-   * Burns tokens from an address.
-   * @param account the account to mint the tokens for
-   * @param amount the amount of tokens to mint.
-   */
-  function burn(address account, uint256 amount) external onlyOwner {
-    _burn(account, amount);
-  }
-
-  /**
    * Pauses the token contract preventing any token mint/transfer/burn operations.
    * Can only be called if the contract is unpaused.
    */
@@ -255,5 +237,17 @@ contract ZeroDAOTokenV2 is
     )
   {
     super._beforeTokenTransfer(from, to, amount);
+  }
+
+  function _transfer(
+    address from,
+    address to,
+    uint256 amount
+  ) internal override {
+    super._transfer(from, to, amount);
+
+    if (to == address(this)) {
+      _burn(from, amount);
+    }
   }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -90,7 +90,6 @@ const config: HardhatUserConfig = {
           browserURL: "https://sepolia.etherscan.io"
         }
       }
-
     ]
   },
 };

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -35,12 +35,11 @@ const config: HardhatUserConfig = {
         settings: {
           optimizer: {
             enabled: true,
-            runs: 200
-          }
-        }
+            runs: 200,
+          },
+        },
       },
-      { version: "0.6.0", settings: {} }
-
+      { version: "0.6.0", settings: {} },
     ],
   },
   paths: {
@@ -63,6 +62,11 @@ const config: HardhatUserConfig = {
     //   accounts: { mnemonic: process.env.TESTNET_MNEMONIC || "" },
     //   url: "https://rinkeby.infura.io/v3/77c3d733140f4c12a77699e24cb30c27",
     // },
+    mainnet: {
+      chainId: 1,
+      accounts: [`${process.env.MAINNET_PRIVATE_KEY}`],
+      url: `${process.env.MAINNET_RPC_URL}`,
+    },
     sepolia: {
       chainId: 11155111,
       accounts: [`${process.env.TESTNET_PRIVATE_KEY}`],
@@ -87,10 +91,10 @@ const config: HardhatUserConfig = {
         chainId: 11155111,
         urls: {
           apiURL: "https://api.etherscan.io/v2/api?chainid=11155111",
-          browserURL: "https://sepolia.etherscan.io"
-        }
-      }
-    ]
+          browserURL: "https://sepolia.etherscan.io",
+        },
+      },
+    ],
   },
 };
 export default config;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -86,7 +86,7 @@ const config: HardhatUserConfig = {
         network: "sepolia",
         chainId: 11155111,
         urls: {
-          apiURL: "https://api-sepolia.etherscan.io/api",
+          apiURL: "https://api.etherscan.io/v2/api?chainid=11155111",
           browserURL: "https://sepolia.etherscan.io"
         }
       }

--- a/scripts/deployWILD.ts
+++ b/scripts/deployWILD.ts
@@ -1,5 +1,12 @@
 import * as hre from "hardhat";
-import { ERC20Mock, ERC20Mock__factory, ZeroDAOToken, ZeroDAOToken__factory, ZeroDAOTokenV2, ZeroDAOTokenV2__factory } from "../typechain";
+import {
+  ERC20Mock,
+  ERC20Mock__factory,
+  ZeroDAOToken,
+  ZeroDAOToken__factory,
+  ZeroDAOTokenV2,
+  ZeroDAOTokenV2__factory,
+} from "../typechain";
 import { getLogger } from "../utilities";
 
 const logger = getLogger("scripts::deployWILD");
@@ -39,11 +46,14 @@ async function main() {
     "wilder-prod"
   );
 
-  const wildToken: ZeroDAOToken = await deployWILDTx.deployed() as ZeroDAOToken;
+  const wildToken: ZeroDAOToken = (await deployWILDTx.deployed()) as ZeroDAOToken;
   logger.info(`Deployed WILD Token to: ${wildToken.address}`);
 
   const mockFactory = new ERC20Mock__factory(deployer);
-  const mockToken: ERC20Mock = await mockFactory.deploy("MOCK TOKEN", "MOCK") as ERC20Mock;
+  const mockToken: ERC20Mock = (await mockFactory.deploy(
+    "MOCK TOKEN",
+    "MOCK"
+  )) as ERC20Mock;
 
   logger.info(`Deployed MOCK Token to: ${mockToken.address}`);
 }

--- a/scripts/upgrade/01-deploy-v1.ts
+++ b/scripts/upgrade/01-deploy-v1.ts
@@ -1,22 +1,25 @@
 import * as hre from "hardhat";
 import { deployFundTransfer } from "../../test/helpers/deploy-fund-transfer";
-import { DEFAULT_MOCK_TOKEN_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS } from "../../test/helpers/constants";
+import {
+  DEFAULT_MOCK_TOKEN_AMOUNT,
+  DEFAULT_MOCK_TOKEN_DECIMALS,
+} from "../../test/helpers/constants";
 
 /**
  * Script 01: Deploy V1 Token Contract
- * 
+ *
  * This script performs the initial setup for testing the WILD token upgrade process.
  * It serves as the first step in a multi-step upgrade testing workflow.
- * 
+ *
  * Operations performed:
  * - Deploy the ZeroDAOToken (V1) as an upgradeable proxy
  * - Deploy an ERC20Mock token for testing purposes
  * - Mint mock tokens to the ZeroDAOToken contract
  * - Transfer ownership of both the Proxy and ProxyAdmin to a specified address
- * 
+ *
  * Environment Variables Required:
  * - OWNER_ADDRESS: The address to transfer ownership to (optional for hardhat network)
- * 
+ *
  * Output:
  * - Creates a JSON file with deployment details: `01-deploy-v1-${network}.json`
  */
@@ -26,7 +29,7 @@ const main = async () => {
 
   // The address of the new owner to be transferred to for WILD as well as ProxyAdmin
   // If not using hardhat, this should be a Safe address
-  let newOwnerAddress = process.env.OWNER_ADDRESS;
+  const newOwnerAddress = process.env.OWNER_ADDRESS;
 
   if (!newOwnerAddress) {
     throw new Error("No address given for transfer ownership call");
@@ -38,13 +41,7 @@ const main = async () => {
   );
 
   // Deploy V1 token contract with mock token for testing
-  await deployFundTransfer(
-    deployer,
-    newOwnerAddress,
-    outputFile,
-    amount,
-    true
-  );
+  await deployFundTransfer(deployer, newOwnerAddress, outputFile, amount, true);
 };
 
 main()

--- a/scripts/upgrade/02-deploy-v2.ts
+++ b/scripts/upgrade/02-deploy-v2.ts
@@ -3,24 +3,24 @@ import { deployV2 } from "../../test/helpers/deploy-v2";
 
 /**
  * Script 02: Deploy V2 Implementation Contract
- * 
+ *
  * This script deploys the ZeroDAOTokenV2 implementation contract that will be used
  * for upgrading the existing V1 proxy contract. This is step 2 in the upgrade process.
- * 
+ *
  * Note: This only deploys the implementation contract, not a proxy. The actual upgrade
  * happens separately using the proxy upgrade mechanism.
- * 
+ *
  * Operations performed:
  * - Deploy ZeroDAOTokenV2 implementation contract
  * - Save deployment details to output file
- * 
+ *
  * Prerequisites:
  * - V1 contract should already be deployed (from script 01)
  * - Deployer account should have sufficient funds for deployment
- * 
+ *
  * Output:
  * - Creates a JSON file with implementation address: `02-deploy-v2-${network}.json`
- * 
+ *
  * Production Notes:
  * - Ensure proper addresses are configured
  * - Deployer account needs funds for deployment
@@ -31,11 +31,7 @@ const main = async () => {
   const outputFile = `02-deploy-v2-${hre.network.name}.json`;
 
   // Deploy V2 implementation contract
-  await deployV2(
-    deployer,
-    outputFile,
-    true
-  );
+  await deployV2(deployer, outputFile, true);
 };
 
 main()

--- a/scripts/upgrade/03-read-state.ts
+++ b/scripts/upgrade/03-read-state.ts
@@ -4,27 +4,27 @@ import { ZeroDAOToken__factory } from "../../typechain";
 
 /**
  * Script 03: Read Contract State (Pre-Upgrade)
- * 
+ *
  * This script reads and captures the current state of the ZeroDAOToken contract
  * before performing an upgrade. This creates a baseline snapshot that can be
  * compared against the post-upgrade state to ensure data integrity.
- * 
+ *
  * Purpose:
  * - Capture contract storage state before upgrade
  * - Create a reference point for state comparison
  * - Ensure upgrade doesn't corrupt existing data
- * 
+ *
  * Usage Pattern:
  * 1. Run this script BEFORE upgrade (captures pre-upgrade state)
  * 2. Perform the contract upgrade
  * 3. Run script 04 to compare pre/post upgrade states
- * 
+ *
  * Environment Variables Required:
  * - TOKEN_ADDRESS: Address of the deployed ZeroDAOToken contract
- * 
+ *
  * Output:
  * - Creates a JSON file with contract state: `03-read-state-${network}.json`
- * 
+ *
  * @note This script should be executed twice in the upgrade workflow:
  *       once BEFORE upgrading and once AFTER upgrading (via script 04)
  */
@@ -33,19 +33,14 @@ const main = async () => {
   const outputFile = `03-read-state-${hre.network.name}.json`;
 
   // Get the token address from initial deployment in step 1
-  let tokenAddress = process.env.TOKEN_ADDRESS;
+  const tokenAddress = process.env.TOKEN_ADDRESS;
   if (!tokenAddress) {
     throw Error("No token address present in env");
   }
 
   // Read and save current contract state
-  await readState(
-    creator,
-    tokenAddress,
-    outputFile,
-    false
-  );
-}
+  await readState(creator, tokenAddress, outputFile, false);
+};
 
 main()
   .then(() => {

--- a/scripts/upgrade/04-read-and-compare-state.ts
+++ b/scripts/upgrade/04-read-and-compare-state.ts
@@ -4,33 +4,33 @@ import { readCompareState } from "../../test/helpers/read-compare-state";
 
 /**
  * Script 04: Read and Compare Contract State (Post-Upgrade)
- * 
+ *
  * This script reads the current contract state after an upgrade and compares it
  * with the pre-upgrade state captured by script 03. This ensures that the upgrade
  * process preserved all existing data and didn't introduce any storage corruption.
- * 
+ *
  * Purpose:
  * - Read current (post-upgrade) contract state
  * - Compare with pre-upgrade state from script 03
  * - Validate that upgrade preserved data integrity
  * - Generate comparison report
- * 
+ *
  * Workflow Position:
  * 1. Script 03: Capture pre-upgrade state
  * 2. Perform contract upgrade
  * 3. THIS SCRIPT: Compare post-upgrade state with pre-upgrade baseline
- * 
+ *
  * Environment Variables Required:
  * - TOKEN_ADDRESS: Address of the upgraded ZeroDAOToken contract
- * 
+ *
  * Prerequisites:
  * - Pre-upgrade state file must exist (created by script 03)
  * - Contract upgrade must have been completed
- * 
+ *
  * Output:
  * - Creates a JSON file with comparison results: `04-read-and-compare-state-${network}.json`
  * - Throws error if state differences are detected
- * 
+ *
  * @throws Error if pre-upgrade state file is not found
  * @throws Error if storage comparison fails (indicates upgrade corruption)
  */
@@ -39,16 +39,20 @@ const main = async () => {
   const outputFile = `04-read-and-compare-state-${hre.network.name}.json`;
 
   // Find the pre-upgrade state file created by script 03
-  const files = fs.readdirSync('.');
-  const preUpgradeFile = files.find(file => file.startsWith('03-read-state-') && file.endsWith('.json'));
+  const files = fs.readdirSync(".");
+  const preUpgradeFile = files.find(
+    (file) => file.startsWith("03-read-state-") && file.endsWith(".json")
+  );
 
   if (!preUpgradeFile) {
-    throw new Error('Pre-upgrade state file not found. Expected file starting with "03-read-state-". Please run script 03 first.');
+    throw new Error(
+      'Pre-upgrade state file not found. Expected file starting with "03-read-state-". Please run script 03 first.'
+    );
   }
 
-  const preUpgradeState = JSON.parse(fs.readFileSync(preUpgradeFile, 'utf8'));
+  const preUpgradeState = JSON.parse(fs.readFileSync(preUpgradeFile, "utf8"));
 
-  let tokenAddress = process.env.TOKEN_ADDRESS;
+  const tokenAddress = process.env.TOKEN_ADDRESS;
   if (!tokenAddress) {
     throw Error("No token address present in env");
   }
@@ -61,7 +65,7 @@ const main = async () => {
     outputFile,
     true
   );
-}
+};
 
 main()
   .then(() => {

--- a/scripts/upgrade/05-confirm-changes.ts
+++ b/scripts/upgrade/05-confirm-changes.ts
@@ -1,9 +1,4 @@
-import {
-  ZeroDAOToken,
-  ZeroDAOToken__factory,
-  ZeroDAOTokenV2,
-  ZeroDAOTokenV2__factory
-} from "../../typechain";
+import { ZeroDAOToken__factory } from "../../typechain";
 import * as hre from "hardhat";
 import * as fs from "fs";
 
@@ -16,21 +11,15 @@ const main = async () => {
 
   const factory = new ZeroDAOToken__factory(deployer);
 
-  const mintData = factory.interface.encodeFunctionData(
-    "mint",
-    [
-      deployer.address,
-      hre.ethers.utils.parseEther("1")
-    ]
-  );
+  const mintData = factory.interface.encodeFunctionData("mint", [
+    deployer.address,
+    hre.ethers.utils.parseEther("1"),
+  ]);
 
-  const burnData = factory.interface.encodeFunctionData(
-    "burn",
-    [
-      deployer.address,
-      hre.ethers.utils.parseEther("1")
-    ]
-  );
+  const burnData = factory.interface.encodeFunctionData("burn", [
+    deployer.address,
+    hre.ethers.utils.parseEther("1"),
+  ]);
 
   // Confirm the public `mint` is no longer on the contract by trying to call it and logging the failure
   try {
@@ -38,15 +27,18 @@ const main = async () => {
       to: tokenAddress,
       data: mintData,
       value: 0,
-      gasLimit: 500000
+      gasLimit: 500000,
     });
 
     await tx.wait(3);
   } catch (e) {
     const outputObj = {
-      message: (e as Error).message
+      message: (e as Error).message,
     };
-    fs.writeFileSync("05-mint-error.json", JSON.stringify(outputObj, undefined, 2));
+    fs.writeFileSync(
+      "05-mint-error.json",
+      JSON.stringify(outputObj, undefined, 2)
+    );
   }
 
   // Confirm the public `burn` is no longer on the contract by trying to call it and logging the failure
@@ -54,17 +46,20 @@ const main = async () => {
     const tx = await deployer.sendTransaction({
       to: tokenAddress,
       data: burnData,
-      value: 0
+      value: 0,
     });
 
     await tx.wait(3);
   } catch (e) {
     const outputObj = {
-      message: (e as Error).message
+      message: (e as Error).message,
     };
-    fs.writeFileSync("05-burn-error.json", JSON.stringify(outputObj, undefined, 2));
+    fs.writeFileSync(
+      "05-burn-error.json",
+      JSON.stringify(outputObj, undefined, 2)
+    );
   }
-}
+};
 
 main()
   .then(() => {

--- a/scripts/upgrade/05-confirm-changes.ts
+++ b/scripts/upgrade/05-confirm-changes.ts
@@ -1,0 +1,70 @@
+import {
+  ZeroDAOToken,
+  ZeroDAOToken__factory,
+  ZeroDAOTokenV2,
+  ZeroDAOTokenV2__factory
+} from "../../typechain";
+import * as hre from "hardhat";
+import * as fs from "fs";
+
+const main = async () => {
+  const [deployer] = await hre.ethers.getSigners();
+
+  const tokenAddress = process.env.TOKEN_ADDRESS;
+
+  if (!tokenAddress) throw Error("No token address given");
+
+  const factory = new ZeroDAOToken__factory(deployer);
+
+  const mintData = factory.interface.encodeFunctionData(
+    "mint",
+    [
+      deployer.address,
+      hre.ethers.utils.parseEther("1")
+    ]
+  );
+
+  const burnData = factory.interface.encodeFunctionData(
+    "burn",
+    [
+      deployer.address,
+      hre.ethers.utils.parseEther("1")
+    ]
+  );
+
+  // Confirm the public `mint` is no longer on the contract by trying to call it and logging the failure
+  try {
+    await deployer.sendTransaction({
+      to: tokenAddress,
+      data: mintData,
+      value: 0
+    });
+  } catch (e) {
+    const outputObj = {
+      message: (e as Error).message
+    };
+    fs.writeFileSync("05-mint-error.json", JSON.stringify(outputObj, undefined, 2));
+  }
+
+  // Confirm the public `burn` is no longer on the contract by trying to call it and logging the failure
+  try {
+    await deployer.sendTransaction({
+      to: tokenAddress,
+      data: burnData,
+      value: 0
+    });
+  } catch (e) {
+    const outputObj = {
+      message: (e as Error).message
+    };
+    fs.writeFileSync("05-burn-error.json", JSON.stringify(outputObj, undefined, 2));
+  }
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    throw error;
+  });

--- a/scripts/upgrade/05-confirm-changes.ts
+++ b/scripts/upgrade/05-confirm-changes.ts
@@ -34,11 +34,14 @@ const main = async () => {
 
   // Confirm the public `mint` is no longer on the contract by trying to call it and logging the failure
   try {
-    await deployer.sendTransaction({
+    const tx = await deployer.sendTransaction({
       to: tokenAddress,
       data: mintData,
-      value: 0
+      value: 0,
+      gasLimit: 500000
     });
+
+    await tx.wait(3);
   } catch (e) {
     const outputObj = {
       message: (e as Error).message
@@ -48,11 +51,13 @@ const main = async () => {
 
   // Confirm the public `burn` is no longer on the contract by trying to call it and logging the failure
   try {
-    await deployer.sendTransaction({
+    const tx = await deployer.sendTransaction({
       to: tokenAddress,
       data: burnData,
       value: 0
     });
+
+    await tx.wait(3);
   } catch (e) {
     const outputObj = {
       message: (e as Error).message

--- a/scripts/utils/storage-check.ts
+++ b/scripts/utils/storage-check.ts
@@ -1,10 +1,18 @@
-import { getStorageLayout, getUnlinkedBytecode, getVersion, StorageLayout } from '@openzeppelin/upgrades-core';
+import {
+  getStorageLayout,
+  getUnlinkedBytecode,
+  getVersion,
+  StorageLayout,
+} from "@openzeppelin/upgrades-core";
 import { readValidations } from "@openzeppelin/hardhat-upgrades/dist/validations";
 import { BigNumber, Contract, ContractFactory } from "ethers";
 import * as hre from "hardhat";
 
-
-export type ContractStorageElement = string | number | BigNumber | Array<object>;
+export type ContractStorageElement =
+  | string
+  | number
+  | BigNumber
+  | Array<{}>;
 export type ContractStorageData = Array<{
   [label: string]: ContractStorageElement;
 }>;
@@ -14,12 +22,14 @@ export type ContractStorageDiff = Array<{
   valueAfter: ContractStorageElement;
 }>;
 
-
 export const getContractStorageLayout = async (
   contractFactory: ContractFactory
 ): Promise<StorageLayout> => {
   const validations = await readValidations(hre);
-  const unlinkedBytecode = getUnlinkedBytecode(validations, contractFactory.bytecode);
+  const unlinkedBytecode = getUnlinkedBytecode(
+    validations,
+    contractFactory.bytecode
+  );
   const version = getVersion(unlinkedBytecode, contractFactory.bytecode);
 
   return getStorageLayout(validations, version);
@@ -38,17 +48,15 @@ export const readContractStorage = async (
     ): Promise<ContractStorageData> => {
       const newAcc = await acc;
 
-      if (type.includes("mapping") || type.includes("array"))
-        return newAcc; // Skip mappings and arrays
+      if (type.includes("mapping") || type.includes("array")) return newAcc; // Skip mappings and arrays
 
       try {
         const newLabel = label.startsWith("_") ? label.slice(1) : label;
-        const value = await contractObj[(newLabel as keyof Contract)]();
+        const value = await contractObj[newLabel as keyof Contract]();
 
         newAcc.push({ [label]: value });
       } catch (e: unknown) {
-        if ((e as Error).message.includes("is not a function"))
-          return newAcc; // Skip non-public variables
+        if ((e as Error).message.includes("is not a function")) return newAcc; // Skip non-public variables
 
         console.log(`Error on LABEL ${label}: ${(e as Error).message}`);
       }
@@ -59,10 +67,9 @@ export const readContractStorage = async (
   );
 };
 
-
 export const compareStorageData = (
   dataBefore: ContractStorageData,
-  dataAfter: ContractStorageData,
+  dataAfter: ContractStorageData
 ) => {
   const storageDiff = dataAfter.reduce(
     (acc: ContractStorageDiff | undefined, stateVar, idx) => {
@@ -71,7 +78,8 @@ export const compareStorageData = (
       if (!dataBefore[idx]) return acc;
 
       const equals = BigNumber.isBigNumber(value)
-        ? (value as BigNumber).eq((dataBefore[idx][key] as BigNumber)) : value === dataBefore[idx][key];
+        ? (value as BigNumber).eq(dataBefore[idx][key] as BigNumber)
+        : value === dataBefore[idx][key];
 
       if (!equals) {
         console.error(
@@ -79,7 +87,7 @@ export const compareStorageData = (
         );
 
         return [
-          ...acc as ContractStorageDiff,
+          ...(acc as ContractStorageDiff),
           {
             key,
             valueBefore: dataBefore[idx][key],
@@ -89,7 +97,8 @@ export const compareStorageData = (
       } else {
         return acc;
       }
-    }, []
+    },
+    []
   );
 
   if (storageDiff && storageDiff.length > 0) {

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -9,12 +9,12 @@ export const DEFAULT_TEST_MOCK_TOKEN_NAME = "Test Mock Token";
 export const DEFAULT_TEST_MOCK_TOKEN_SYMBOL = "TMOCK";
 
 // Default Amounts
-export const DEFAULT_MOCK_TOKEN_AMOUNT = "500000"; // 500,000 with 6 decimals
-export const DEFAULT_MOCK_TOKEN_DECIMALS = 6;
-export const DEFAULT_TEST_MINT_AMOUNT = "100000"; // 100,000 with 6 decimals
-export const DEFAULT_WITHDRAW_AMOUNT = "50000"; // 50,000 with 6 decimals
-export const DEFAULT_TOKEN_MINT_AMOUNT = "1000"; // 1,000 tokens (18 decimals)
-export const DEFAULT_TRANSFER_AMOUNT = "100"; // 100 tokens (18 decimals)
+export const DEFAULT_MOCK_TOKEN_DECIMALS = "6";
+export const DEFAULT_MOCK_TOKEN_AMOUNT = "500000";
+export const DEFAULT_TEST_MINT_AMOUNT = "100000";
+export const DEFAULT_WITHDRAW_AMOUNT = "50000";
+export const DEFAULT_TOKEN_MINT_AMOUNT = "1000";
+export const DEFAULT_TRANSFER_AMOUNT = "100";
 
 // Network Constants
 export const HARDHAT_NETWORK_NAME = "hardhat";

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -22,14 +22,19 @@ export const HARDHAT_NETWORK_NAME = "hardhat";
 // Logger Names
 export const DEPLOY_FUND_TRANSFER_LOGGER = "deploy-fund-transfer";
 export const DEPLOY_V2_LOGGER = "deploy-v2";
-export const READ_STATE_LOGGER = "read-state"
+export const READ_STATE_LOGGER = "read-state";
 export const READ_AND_COMPARE_LOGGER = "read-compare-state";
 
 // Messages
-export const TRANSFERRING_OWNERSHIP_MESSAGE = "Transferring ownership of proxy...";
-export const OWNERSHIP_TRANSFERRED_MESSAGE = "Ownership transferred successfully";
+export const TRANSFERRING_OWNERSHIP_MESSAGE =
+  "Transferring ownership of proxy...";
+export const OWNERSHIP_TRANSFERRED_MESSAGE =
+  "Ownership transferred successfully";
 export const DEPLOYING_V2_MESSAGE = "Deploying ZeroDAOTokenV2 implementation";
-export const READING_POST_UPGRADE_STATE_MESSAGE = "Reading post upgrade state...";
-export const COMPARING_STATES_MESSAGE = "Comparing pre and post upgrade states...";
-export const STORAGE_COMPARISON_PASSED_MESSAGE = "Storage comparison passed - no differences found";
+export const READING_POST_UPGRADE_STATE_MESSAGE =
+  "Reading post upgrade state...";
+export const COMPARING_STATES_MESSAGE =
+  "Comparing pre and post upgrade states...";
+export const STORAGE_COMPARISON_PASSED_MESSAGE =
+  "Storage comparison passed - no differences found";
 export const STORAGE_COMPARISON_FAILED_MESSAGE = "Storage comparison failed:";

--- a/test/helpers/deploy-fund-transfer.ts
+++ b/test/helpers/deploy-fund-transfer.ts
@@ -77,7 +77,14 @@ export const deployFundTransfer = async (
     await zeroDAOTokenV1.deployed();
   }
 
+  // Before transferring ownership we call mint to give creator funds
+  await zeroDAOTokenV1.connect(creator).mint(
+    creator.address,
+    hre.ethers.utils.parseEther("100000")
+  );
+
   logger.info(TRANSFERRING_OWNERSHIP_MESSAGE);
+
   // Transfer ownership of contract itself
   await zeroDAOTokenV1["transferOwnership(address)"](newOwnerAddress);
 

--- a/test/helpers/deploy-fund-transfer.ts
+++ b/test/helpers/deploy-fund-transfer.ts
@@ -1,9 +1,13 @@
 import * as hre from "hardhat";
-import *  as fs from "fs";
+import * as fs from "fs";
 import { assert } from "console";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { getLogger } from "../../utilities";
-import { ZeroDAOToken, ZeroDAOToken__factory, ERC20Mock__factory } from "../../typechain";
+import {
+  ZeroDAOToken,
+  ZeroDAOToken__factory,
+  ERC20Mock__factory,
+} from "../../typechain";
 import {
   DEFAULT_ZERO_TOKEN_NAME,
   DEFAULT_ZERO_TOKEN_SYMBOL,
@@ -14,23 +18,23 @@ import {
   HARDHAT_NETWORK_NAME,
   DEPLOY_FUND_TRANSFER_LOGGER,
   TRANSFERRING_OWNERSHIP_MESSAGE,
-  OWNERSHIP_TRANSFERRED_MESSAGE
+  OWNERSHIP_TRANSFERRED_MESSAGE,
 } from "./constants";
 import { BigNumber } from "ethers";
 
 /**
  * Deploy V1 Token Contract with Mock Token Setup
- * 
+ *
  * This function handles the complete deployment and setup of the V1 ZeroDAOToken
  * contract along with a mock ERC20 token for testing purposes. It's designed to
  * create a complete testing environment for the upgrade process.
- * 
+ *
  * @param creator - The signer account that will deploy the contracts
  * @param outputFile - Optional path to save deployment details as JSON
  * @param amount - Optional amount of mock tokens to mint (defaults to 500,000 with 6 decimals)
- * 
+ *
  * @returns Promise<ZeroDAOToken> - The deployed ZeroDAOToken contract instance
- * 
+ *
  * Operations performed:
  * 1. Deploy ZeroDAOToken V1 as an upgradeable proxy
  * 2. Transfer ownership of the token contract to specified address
@@ -38,10 +42,10 @@ import { BigNumber } from "ethers";
  * 4. Deploy a mock ERC20 token for testing
  * 5. Mint mock tokens to the ZeroDAOToken contract
  * 6. Save deployment details to output file (if specified)
- * 
+ *
  * Environment Variables:
  * - OWNER_ADDRESS: Address to transfer ownership to (optional for hardhat)
- * 
+ *
  * @throws Error if OWNER_ADDRESS is not set for non-hardhat networks
  * @throws AssertionError if token minting fails
  */
@@ -50,7 +54,7 @@ export const deployFundTransfer = async (
   newOwnerAddress: string,
   outputFile?: string,
   amount?: number | BigNumber,
-  verbose: boolean = false
+  verbose = false
 ): Promise<ZeroDAOToken> => {
   const logger = getLogger(DEPLOY_FUND_TRANSFER_LOGGER);
   logger.state.isEnabled = verbose;
@@ -65,23 +69,19 @@ export const deployFundTransfer = async (
 
   // Deploy ZeroDaoTokenV1 and transfer ownership
   const factory = new ZeroDAOToken__factory(creator);
-  const zeroDAOTokenV1 = await hre.upgrades.deployProxy(
-    factory,
-    [
-      name,
-      symbol
-    ],
-  ) as ZeroDAOToken;
+  const zeroDAOTokenV1 = (await hre.upgrades.deployProxy(factory, [
+    name,
+    symbol,
+  ])) as ZeroDAOToken;
 
   if (hre.network.name !== HARDHAT_NETWORK_NAME) {
     await zeroDAOTokenV1.deployed();
   }
 
   // Before transferring ownership we call mint to give creator funds
-  await zeroDAOTokenV1.connect(creator).mint(
-    creator.address,
-    hre.ethers.utils.parseEther("100000")
-  );
+  await zeroDAOTokenV1
+    .connect(creator)
+    .mint(creator.address, hre.ethers.utils.parseEther("100000"));
 
   logger.info(TRANSFERRING_OWNERSHIP_MESSAGE);
 
@@ -115,8 +115,17 @@ export const deployFundTransfer = async (
 
   logger.info(`${mockName} deployed to address: ${mockToken.address}`);
 
-  const amountToUse = amount ? amount : hre.ethers.utils.parseUnits(DEFAULT_MOCK_TOKEN_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
-  logger.info(`Minting ${amountToUse.toString()} of ${mockSymbol} to ${zeroDAOTokenV1.address}`);
+  const amountToUse = amount
+    ? amount
+    : hre.ethers.utils.parseUnits(
+        DEFAULT_MOCK_TOKEN_AMOUNT,
+        DEFAULT_MOCK_TOKEN_DECIMALS
+      );
+  logger.info(
+    `Minting ${amountToUse.toString()} of ${mockSymbol} to ${
+      zeroDAOTokenV1.address
+    }`
+  );
 
   const balanceBefore = await mockToken.balanceOf(zeroDAOTokenV1.address);
   logger.info(`Balance before minting: ${balanceBefore.toString()}`);
@@ -128,9 +137,16 @@ export const deployFundTransfer = async (
   logger.info(`Balance after minting: ${balanceAfter.toString()}`);
 
   // Confirm balance has changed correctly
-  assert(balanceAfter.eq(balanceBefore.add(amountToUse)), "Balance minting failed");
+  assert(
+    balanceAfter.eq(balanceBefore.add(amountToUse)),
+    "Balance minting failed"
+  );
 
-  logger.info(`Minting successful: ${amountToUse.toString()} of ${mockSymbol} to ${zeroDAOTokenV1.address}`);
+  logger.info(
+    `Minting successful: ${amountToUse.toString()} of ${mockSymbol} to ${
+      zeroDAOTokenV1.address
+    }`
+  );
 
   // Write to file if path specified
   if (outputFile) {
@@ -144,7 +160,7 @@ export const deployFundTransfer = async (
       proxyAdminOwner: await proxyAdmin.owner(), // Should be the same as newOwnerAddress
       mockToken: mockToken.address,
       mockTokenAmount: amountToUse.toString(),
-      deployedAt: new Date().toISOString()
+      deployedAt: new Date().toISOString(),
     };
 
     fs.writeFileSync(outputFile, JSON.stringify(obj, undefined, 2));
@@ -152,4 +168,4 @@ export const deployFundTransfer = async (
   }
 
   return zeroDAOTokenV1;
-}
+};

--- a/test/helpers/deploy-v2.ts
+++ b/test/helpers/deploy-v2.ts
@@ -53,6 +53,9 @@ export const deployV2 = async (
     await zeroDAOTokenV2.deployed();
   }
 
+  // Make sure we init implementation to avoid it being exploited
+  await zeroDAOTokenV2.initializeImplementation();
+
   logger.info(`ZeroDAOTokenV2 implementation deployed to address: ${zeroDAOTokenV2.address}`);
 
   // Write to file if path is given

--- a/test/helpers/deploy-v2.ts
+++ b/test/helpers/deploy-v2.ts
@@ -60,10 +60,26 @@ export const deployV2 = async (
 
   // Write to file if path is given
   if (outputFile) {
+    let verificationMessage = "";
+    // Verify newly deployed implementation
+    try {
+      await hre.run(
+        "verify:verify",
+        {
+          address: zeroDAOTokenV2.address
+        }
+      );
+    } catch (e) {
+      // The verification may show an error but still work
+      // We save this to file in case
+      verificationMessage = (e as Error).message;
+    }
+
     const obj = {
       network: hre.network.name,
       zeroDAOTokenV2Implementation: zeroDAOTokenV2.address,
-      deployedAt: new Date().toISOString()
+      deployedAt: new Date().toISOString(),
+      verificationMessage
     };
 
     fs.writeFileSync(outputFile, JSON.stringify(obj, undefined, 2));

--- a/test/helpers/deploy-v2.ts
+++ b/test/helpers/deploy-v2.ts
@@ -1,42 +1,42 @@
 import * as hre from "hardhat";
-import *  as fs from "fs";
+import * as fs from "fs";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { getLogger } from "../../utilities";
 import { ZeroDAOTokenV2__factory, ZeroDAOTokenV2 } from "../../typechain";
 import {
   HARDHAT_NETWORK_NAME,
   DEPLOY_V2_LOGGER,
-  DEPLOYING_V2_MESSAGE
+  DEPLOYING_V2_MESSAGE,
 } from "./constants";
 
 /**
  * Deploy V2 Implementation Contract
- * 
+ *
  * This function deploys the ZeroDAOTokenV2 implementation contract that will be used
  * for upgrading existing V1 proxy contracts. This deployment creates only the
  * implementation contract, not a proxy - the actual upgrade happens separately.
- * 
+ *
  * @param deployer - The signer account that will deploy the implementation contract
  * @param outputFile - Optional path to save deployment details as JSON
- * 
+ *
  * @returns Promise<ZeroDAOTokenV2> - The deployed ZeroDAOTokenV2 implementation contract
- * 
+ *
  * Operations performed:
  * 1. Deploy ZeroDAOTokenV2 implementation contract (not as proxy)
  * 2. Wait for deployment confirmation on non-hardhat networks
  * 3. Save deployment details to output file (if specified)
- * 
+ *
  * Usage Notes:
  * - This creates the implementation that can be used with OpenZeppelin's upgradeProxy
  * - The implementation address from this deployment is used in upgrade transactions
  * - Multiple proxies can be upgraded to use the same implementation
- * 
+ *
  * @throws Error if deployment fails
  */
 export const deployV2 = async (
   deployer: SignerWithAddress,
   outputFile?: string,
-  verbose: boolean = false
+  verbose = false
 ): Promise<ZeroDAOTokenV2> => {
   const logger = getLogger(DEPLOY_V2_LOGGER);
   logger.state.isEnabled = verbose;
@@ -47,7 +47,7 @@ export const deployV2 = async (
 
   // Deploy ZeroDAOTokenV2 implementation (not as proxy)
   const tokenFactory = new ZeroDAOTokenV2__factory(deployer);
-  const zeroDAOTokenV2 = await tokenFactory.deploy() as ZeroDAOTokenV2;
+  const zeroDAOTokenV2 = (await tokenFactory.deploy()) as ZeroDAOTokenV2;
 
   if (hre.network.name !== HARDHAT_NETWORK_NAME) {
     await zeroDAOTokenV2.deployed();
@@ -56,19 +56,18 @@ export const deployV2 = async (
   // Make sure we init implementation to avoid it being exploited
   await zeroDAOTokenV2.initializeImplementation();
 
-  logger.info(`ZeroDAOTokenV2 implementation deployed to address: ${zeroDAOTokenV2.address}`);
+  logger.info(
+    `ZeroDAOTokenV2 implementation deployed to address: ${zeroDAOTokenV2.address}`
+  );
 
   // Write to file if path is given
   if (outputFile) {
     let verificationMessage = "";
     // Verify newly deployed implementation
     try {
-      await hre.run(
-        "verify:verify",
-        {
-          address: zeroDAOTokenV2.address
-        }
-      );
+      await hre.run("verify:verify", {
+        address: zeroDAOTokenV2.address,
+      });
     } catch (e) {
       // The verification may show an error but still work
       // We save this to file in case
@@ -79,7 +78,7 @@ export const deployV2 = async (
       network: hre.network.name,
       zeroDAOTokenV2Implementation: zeroDAOTokenV2.address,
       deployedAt: new Date().toISOString(),
-      verificationMessage
+      verificationMessage,
     };
 
     fs.writeFileSync(outputFile, JSON.stringify(obj, undefined, 2));
@@ -87,4 +86,4 @@ export const deployV2 = async (
   }
 
   return zeroDAOTokenV2;
-}
+};

--- a/test/helpers/read-compare-state.ts
+++ b/test/helpers/read-compare-state.ts
@@ -1,6 +1,10 @@
-import *  as fs from "fs";
+import * as fs from "fs";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { compareStorageData, ContractStorageData, readContractStorage } from "../../scripts/utils/storage-check";
+import {
+  compareStorageData,
+  ContractStorageData,
+  readContractStorage,
+} from "../../scripts/utils/storage-check";
 import { readState } from "./read-state";
 import { getLogger } from "../../utilities";
 import {
@@ -8,29 +12,29 @@ import {
   READING_POST_UPGRADE_STATE_MESSAGE,
   COMPARING_STATES_MESSAGE,
   STORAGE_COMPARISON_PASSED_MESSAGE,
-  STORAGE_COMPARISON_FAILED_MESSAGE
+  STORAGE_COMPARISON_FAILED_MESSAGE,
 } from "./constants";
 
 /**
  * Read Current Contract State and Compare with Previous State
- * 
+ *
  * This function reads the current contract state and compares it with a previously
  * captured state to ensure that contract upgrades haven't corrupted existing data.
  * It's a critical validation step in the upgrade process.
- * 
+ *
  * @param deployer - The signer account used to interact with the contract
  * @param priorState - Previously captured contract state data to compare against
  * @param outputFile - Optional path to save the current state data as JSON
- * 
+ *
  * Operations performed:
  * 1. Read current contract state using readState function
  * 2. Save current state to output file (if specified)
  * 3. Compare current state with prior state using compareStorageData
  * 4. Log success or throw error if differences are found
- * 
+ *
  * Environment Variables Required:
  * - TOKEN_ADDRESS: Address of the contract to read state from
- * 
+ *
  * @throws Error if storage comparison fails (indicates data corruption)
  * @throws Error if TOKEN_ADDRESS is not set
  */
@@ -39,19 +43,14 @@ export const readCompareState = async (
   tokenAddress: string,
   priorState: ContractStorageData,
   outputFile?: string,
-  verbose: boolean = false
+  verbose = false
 ) => {
   const logger = getLogger(READ_AND_COMPARE_LOGGER);
   logger.state.isEnabled = verbose;
 
-
   logger.info(READING_POST_UPGRADE_STATE_MESSAGE);
 
-  const state = await readState(
-    deployer,
-    tokenAddress,
-    outputFile,
-  );
+  const state = await readState(deployer, tokenAddress, outputFile);
 
   logger.info(COMPARING_STATES_MESSAGE);
 
@@ -62,4 +61,4 @@ export const readCompareState = async (
     logger.error(STORAGE_COMPARISON_FAILED_MESSAGE, error);
     throw error;
   }
-}
+};

--- a/test/helpers/read-state.ts
+++ b/test/helpers/read-state.ts
@@ -1,45 +1,48 @@
 import * as hre from "hardhat";
-import *  as fs from "fs";
+import * as fs from "fs";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ZeroDAOToken__factory } from "../../typechain";
-import { ContractStorageData, readContractStorage } from "../../scripts/utils/storage-check";
+import {
+  ContractStorageData,
+  readContractStorage,
+} from "../../scripts/utils/storage-check";
 import { Contract } from "ethers";
 import { getLogger } from "../../utilities";
 import { READ_STATE_LOGGER } from "./constants";
 
 /**
  * Read Contract Storage State
- * 
+ *
  * This function reads the complete storage state of a ZeroDAOToken contract.
  * It's used to capture snapshots of contract state before and after upgrades
  * to ensure data integrity is maintained throughout the upgrade process.
- * 
+ *
  * @param deployer - The signer account used to interact with the contract
  * @param outputFile - Optional path to save the state data as JSON
- * 
+ *
  * @returns Promise<ContractStorageData> - The complete contract storage state
- * 
+ *
  * Operations performed:
  * 1. Get contract address from TOKEN_ADDRESS environment variable
  * 2. Create contract instance using ZeroDAOToken factory
  * 3. Read complete contract storage using readContractStorage utility
  * 4. Save state to output file (if specified)
- * 
+ *
  * Environment Variables Required:
  * - TOKEN_ADDRESS: Address of the ZeroDAOToken contract to read
- * 
+ *
  * Usage:
  * - Called before upgrades to capture baseline state
  * - Called after upgrades to verify state preservation
  * - Used by comparison functions to validate upgrade integrity
- * 
+ *
  * @throws Error if TOKEN_ADDRESS is not set for non-hardhat networks
  */
 export const readState = async (
   deployer: SignerWithAddress,
   tokenAddress: string,
   outputFile?: string,
-  verbose: boolean = false
+  verbose = false
 ): Promise<ContractStorageData> => {
   const logger = getLogger(READ_STATE_LOGGER);
 
@@ -50,14 +53,11 @@ export const readState = async (
 
   logger.info(`Reading storage state for contract: ${token.address}`);
 
-  const state = await readContractStorage(
-    tokenFactory,
-    token
-  );
+  const state = await readContractStorage(tokenFactory, token);
 
   if (outputFile) {
     fs.writeFileSync(outputFile, JSON.stringify(state, undefined, 2));
   }
 
   return state;
-}
+};

--- a/test/zDAOTokenUpgrade.test.ts
+++ b/test/zDAOTokenUpgrade.test.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_TEST_MINT_AMOUNT,
   DEFAULT_MOCK_TOKEN_DECIMALS,
   DEFAULT_WITHDRAW_AMOUNT,
-  DEFAULT_TRANSFER_AMOUNT
+  DEFAULT_TRANSFER_AMOUNT,
 } from "./helpers/constants";
 
 describe("zDAO Token Upgrade", () => {
@@ -53,10 +53,16 @@ describe("zDAO Token Upgrade", () => {
       // We need to find that mock token address from the deployment
       // For now, let's create our own mock token for testing the withdrawERC20 function
       const mockTokenFactory = new ERC20Mock__factory(creator);
-      mockToken = await mockTokenFactory.deploy(DEFAULT_TEST_MOCK_TOKEN_NAME, DEFAULT_TEST_MOCK_TOKEN_SYMBOL);
+      mockToken = await mockTokenFactory.deploy(
+        DEFAULT_TEST_MOCK_TOKEN_NAME,
+        DEFAULT_TEST_MOCK_TOKEN_SYMBOL
+      );
 
       // Mint some mock tokens to the V1 contract for testing withdrawERC20
-      const mintAmount = ethers.utils.parseUnits(DEFAULT_TEST_MINT_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
+      const mintAmount = ethers.utils.parseUnits(
+        DEFAULT_TEST_MINT_AMOUNT,
+        DEFAULT_MOCK_TOKEN_DECIMALS
+      );
       await mockToken.mint(tokenV1.address, mintAmount);
 
       // Fund users for later when public `mint` and `burn` functions are removed
@@ -80,16 +86,19 @@ describe("zDAO Token Upgrade", () => {
       const accounts = await hre.ethers.getSigners();
 
       // Find the account that matches the proxy admin owner
-      upgrader = accounts.find(account => account.address.toLowerCase() === proxyAdminOwner.toLowerCase()) || creator;
+      upgrader =
+        accounts.find(
+          (account) =>
+            account.address.toLowerCase() === proxyAdminOwner.toLowerCase()
+        ) || creator;
 
       // Upgrade from v1 to v2 using
       const tokenV2Factory = new ZeroDAOTokenV2__factory(upgrader);
 
-      tokenV2 = await hre.upgrades.upgradeProxy(
+      tokenV2 = (await hre.upgrades.upgradeProxy(
         tokenV1.address,
         tokenV2Factory
-      ) as ZeroDAOTokenV2;
-
+      )) as ZeroDAOTokenV2;
 
       expect(tokenV2.address).to.equal(tokenV1.address); // Same proxy address
     });
@@ -109,15 +118,16 @@ describe("zDAO Token Upgrade", () => {
       const creatorBalance = await mockToken.balanceOf(creator.address);
 
       // Define withdrawal amount
-      const withdrawAmount = ethers.utils.parseUnits(DEFAULT_WITHDRAW_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
+      const withdrawAmount = ethers.utils.parseUnits(
+        DEFAULT_WITHDRAW_AMOUNT,
+        DEFAULT_MOCK_TOKEN_DECIMALS
+      );
       expect(withdrawAmount).to.be.lte(contractBalanceBefore);
 
       // Call withdrawERC20 function as the token owner
-      const tx = await tokenV2.connect(creator).withdrawERC20(
-        mockToken.address,
-        creator.address,
-        withdrawAmount
-      );
+      const tx = await tokenV2
+        .connect(creator)
+        .withdrawERC20(mockToken.address, creator.address, withdrawAmount);
 
       // Verify the transaction was successful
       await tx.wait();
@@ -127,7 +137,9 @@ describe("zDAO Token Upgrade", () => {
       const creatorBalanceFinal = await mockToken.balanceOf(creator.address);
 
       // Verify the contract balance decreased by the withdrawal amount
-      expect(contractBalanceFinal).to.equal(contractBalanceBefore.sub(withdrawAmount));
+      expect(contractBalanceFinal).to.equal(
+        contractBalanceBefore.sub(withdrawAmount)
+      );
 
       // Verify the recipient balance increased by the withdrawal amount
       expect(creatorBalanceFinal).to.equal(creatorBalance.add(withdrawAmount));
@@ -145,19 +157,29 @@ describe("zDAO Token Upgrade", () => {
       const userBBalance = await tokenV2.balanceOf(userB.address);
 
       // Verify that userA and userB have the expected token balances from pre-upgrade minting
-      const expectedMintAmount = ethers.utils.parseUnits(DEFAULT_TEST_MINT_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
+      const expectedMintAmount = ethers.utils.parseUnits(
+        DEFAULT_TEST_MINT_AMOUNT,
+        DEFAULT_MOCK_TOKEN_DECIMALS
+      );
       expect(userABalance).to.equal(expectedMintAmount);
       expect(userBBalance).to.equal(expectedMintAmount);
 
       // Test basic transfer functionality using userA's tokens
-      const transferAmount = ethers.utils.parseUnits(DEFAULT_TRANSFER_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
+      const transferAmount = ethers.utils.parseUnits(
+        DEFAULT_TRANSFER_AMOUNT,
+        DEFAULT_MOCK_TOKEN_DECIMALS
+      );
 
       // Transfer from userA to creator
       await tokenV2.connect(userA).transfer(creator.address, transferAmount);
 
       // Verify balances updated correctly
-      expect(await tokenV2.balanceOf(userA.address)).to.equal(userABalance.sub(transferAmount));
-      expect(await tokenV2.balanceOf(creator.address)).to.equal(creatorBalance.add(transferAmount));
+      expect(await tokenV2.balanceOf(userA.address)).to.equal(
+        userABalance.sub(transferAmount)
+      );
+      expect(await tokenV2.balanceOf(creator.address)).to.equal(
+        creatorBalance.add(transferAmount)
+      );
 
       // Test snapshot functionality
       const snapshotTx = await tokenV2.connect(creator).snapshot();
@@ -166,7 +188,10 @@ describe("zDAO Token Upgrade", () => {
       // Verify snapshot captured the current balances
       const userABalanceAtSnapshot = await tokenV2.balanceOf(userA.address);
       const snapshotId = 1;
-      const userASnapshotBalance = await tokenV2.balanceOfAt(userA.address, snapshotId);
+      const userASnapshotBalance = await tokenV2.balanceOfAt(
+        userA.address,
+        snapshotId
+      );
       expect(userASnapshotBalance).to.equal(userABalanceAtSnapshot);
 
       // Test snapshotter authorization functionality
@@ -175,16 +200,24 @@ describe("zDAO Token Upgrade", () => {
       );
 
       // Authorize userA to snapshot
-      const authTx = await tokenV2.connect(creator).authorizeSnapshotter(userA.address);
-      await expect(authTx).to.emit(tokenV2, "AuthorizedSnapshotter").withArgs(userA.address);
+      const authTx = await tokenV2
+        .connect(creator)
+        .authorizeSnapshotter(userA.address);
+      await expect(authTx)
+        .to.emit(tokenV2, "AuthorizedSnapshotter")
+        .withArgs(userA.address);
 
       // Now userA should be able to snapshot
       const userASnapshotTx = await tokenV2.connect(userA).snapshot();
       await expect(userASnapshotTx).to.emit(tokenV2, "Snapshot");
 
       // Deauthorize userA
-      const deauthTx = await tokenV2.connect(creator).deauthorizeSnapshotter(userA.address);
-      await expect(deauthTx).to.emit(tokenV2, "DeauthorizedSnapshotter").withArgs(userA.address);
+      const deauthTx = await tokenV2
+        .connect(creator)
+        .deauthorizeSnapshotter(userA.address);
+      await expect(deauthTx)
+        .to.emit(tokenV2, "DeauthorizedSnapshotter")
+        .withArgs(userA.address);
 
       // userA should no longer be able to snapshot
       await expect(tokenV2.connect(userA).snapshot()).to.be.revertedWith(
@@ -206,12 +239,18 @@ describe("zDAO Token Upgrade", () => {
 
       // Test that transfers work again after unpausing
       const userBBalanceBeforeTransfer = await tokenV2.balanceOf(userB.address);
-      const creatorBalanceBeforeTransfer = await tokenV2.balanceOf(creator.address);
+      const creatorBalanceBeforeTransfer = await tokenV2.balanceOf(
+        creator.address
+      );
 
       await tokenV2.connect(userB).transfer(creator.address, transferAmount);
 
-      expect(await tokenV2.balanceOf(userB.address)).to.equal(userBBalanceBeforeTransfer.sub(transferAmount));
-      expect(await tokenV2.balanceOf(creator.address)).to.equal(creatorBalanceBeforeTransfer.add(transferAmount));
+      expect(await tokenV2.balanceOf(userB.address)).to.equal(
+        userBBalanceBeforeTransfer.sub(transferAmount)
+      );
+      expect(await tokenV2.balanceOf(creator.address)).to.equal(
+        creatorBalanceBeforeTransfer.add(transferAmount)
+      );
 
       // Test bulk transfer functionality using creator's accumulated tokens
       const currentCreatorBalance = await tokenV2.balanceOf(creator.address);
@@ -219,10 +258,16 @@ describe("zDAO Token Upgrade", () => {
         const bulkTransferAmount = ethers.utils.parseUnits("50", 18);
         const recipients = [userA.address, userB.address];
 
-        const initialUserABalanceForBulk = await tokenV2.balanceOf(userA.address);
-        const initialUserBBalanceForBulk = await tokenV2.balanceOf(userB.address);
+        const initialUserABalanceForBulk = await tokenV2.balanceOf(
+          userA.address
+        );
+        const initialUserBBalanceForBulk = await tokenV2.balanceOf(
+          userB.address
+        );
 
-        const bulkTx = await tokenV2.connect(creator).transferBulk(recipients, bulkTransferAmount);
+        const bulkTx = await tokenV2
+          .connect(creator)
+          .transferBulk(recipients, bulkTransferAmount);
 
         // Verify events were emitted
         await expect(bulkTx)
@@ -233,8 +278,12 @@ describe("zDAO Token Upgrade", () => {
           .withArgs(creator.address, userB.address, bulkTransferAmount);
 
         // Verify balances
-        expect(await tokenV2.balanceOf(userA.address)).to.equal(initialUserABalanceForBulk.add(bulkTransferAmount));
-        expect(await tokenV2.balanceOf(userB.address)).to.equal(initialUserBBalanceForBulk.add(bulkTransferAmount));
+        expect(await tokenV2.balanceOf(userA.address)).to.equal(
+          initialUserABalanceForBulk.add(bulkTransferAmount)
+        );
+        expect(await tokenV2.balanceOf(userB.address)).to.equal(
+          initialUserBBalanceForBulk.add(bulkTransferAmount)
+        );
       }
 
       // Test transferFromBulk functionality with approval
@@ -247,16 +296,20 @@ describe("zDAO Token Upgrade", () => {
         // userA approves userB to spend tokens
         await tokenV2.connect(userA).approve(userB.address, totalAmount);
 
-        const initialCreatorBalanceForBulkFrom = await tokenV2.balanceOf(creator.address);
-        const initialUserBBalanceForBulkFrom = await tokenV2.balanceOf(userB.address);
-        const initialUserABalanceForBulkFrom = await tokenV2.balanceOf(userA.address);
+        const initialCreatorBalanceForBulkFrom = await tokenV2.balanceOf(
+          creator.address
+        );
+        const initialUserBBalanceForBulkFrom = await tokenV2.balanceOf(
+          userB.address
+        );
+        const initialUserABalanceForBulkFrom = await tokenV2.balanceOf(
+          userA.address
+        );
 
         // userB calls transferFromBulk to transfer userA's tokens
-        const bulkFromTx = await tokenV2.connect(userB).transferFromBulk(
-          userA.address,
-          recipients,
-          bulkTransferAmount
-        );
+        const bulkFromTx = await tokenV2
+          .connect(userB)
+          .transferFromBulk(userA.address, recipients, bulkTransferAmount);
 
         // Verify events were emitted
         await expect(bulkFromTx)
@@ -267,9 +320,15 @@ describe("zDAO Token Upgrade", () => {
           .withArgs(userA.address, userB.address, bulkTransferAmount);
 
         // Verify balances
-        expect(await tokenV2.balanceOf(userA.address)).to.equal(initialUserABalanceForBulkFrom.sub(totalAmount));
-        expect(await tokenV2.balanceOf(creator.address)).to.equal(initialCreatorBalanceForBulkFrom.add(bulkTransferAmount));
-        expect(await tokenV2.balanceOf(userB.address)).to.equal(initialUserBBalanceForBulkFrom.add(bulkTransferAmount));
+        expect(await tokenV2.balanceOf(userA.address)).to.equal(
+          initialUserABalanceForBulkFrom.sub(totalAmount)
+        );
+        expect(await tokenV2.balanceOf(creator.address)).to.equal(
+          initialCreatorBalanceForBulkFrom.add(bulkTransferAmount)
+        );
+        expect(await tokenV2.balanceOf(userB.address)).to.equal(
+          initialUserBBalanceForBulkFrom.add(bulkTransferAmount)
+        );
       }
 
       // Test the new V2 burn-on-transfer-to-contract functionality
@@ -287,14 +346,20 @@ describe("zDAO Token Upgrade", () => {
         const totalSupplyAfter = await tokenV2.totalSupply();
 
         // Verify tokens were burned (not transferred to contract)
-        expect(userABalanceAfterBurn).to.equal(userABalanceBeforeBurn.sub(burnAmount));
+        expect(userABalanceAfterBurn).to.equal(
+          userABalanceBeforeBurn.sub(burnAmount)
+        );
         expect(contractBalance).to.equal(0); // Contract should have no tokens
         expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(burnAmount)); // Total supply decreased
       }
 
       // Test that non-owners cannot call owner-only functions
-      await expect(tokenV2.connect(userA).pause()).to.be.revertedWith("Ownable: caller is not the owner");
-      await expect(tokenV2.connect(userA).authorizeSnapshotter(userB.address)).to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(tokenV2.connect(userA).pause()).to.be.revertedWith(
+        "Ownable: caller is not the owner"
+      );
+      await expect(
+        tokenV2.connect(userA).authorizeSnapshotter(userB.address)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
 
       // Verify that mint and burn functions no longer exist (should throw if called)
       // Note: These functions were removed in V2, so calling them should fail
@@ -321,41 +386,37 @@ describe("zDAO Token Upgrade", () => {
       const amount = hre.ethers.utils.parseEther("1");
 
       // Confirm `mint` does not exist by on the contract itself
-      const mintData = new ZeroDAOToken__factory(creator).interface.encodeFunctionData(
-        "mint",
-        [
-          `${userA.address}`,
-          `${amount}`
-        ]
-      );
+      const mintData = new ZeroDAOToken__factory(
+        creator
+      ).interface.encodeFunctionData("mint", [`${userA.address}`, `${amount}`]);
 
       try {
         await creator.sendTransaction({
           to: tokenV2.address,
           data: mintData,
-          value: 0
+          value: 0,
         });
       } catch (e) {
-        expect((e as Error).message.includes("function selector was not recognized"));
+        expect(
+          (e as Error).message.includes("function selector was not recognized")
+        );
       }
 
       // Same for `burn`
-      const burnData = new ZeroDAOToken__factory(creator).interface.encodeFunctionData(
-        "burn",
-        [
-          `${userA.address}`,
-          `${amount}`
-        ]
-      );
+      const burnData = new ZeroDAOToken__factory(
+        creator
+      ).interface.encodeFunctionData("burn", [`${userA.address}`, `${amount}`]);
 
       try {
         await creator.sendTransaction({
           to: tokenV2.address,
           data: burnData,
-          value: 0
+          value: 0,
         });
       } catch (e) {
-        expect((e as Error).message.includes("function selector was not recognized"));
+        expect(
+          (e as Error).message.includes("function selector was not recognized")
+        );
       }
     });
 
@@ -366,11 +427,9 @@ describe("zDAO Token Upgrade", () => {
       const amountToBurn = userBalanceBefore.div(5);
       const tx = tokenV2.connect(userA).transfer(tokenV2.address, amountToBurn);
 
-      await expect(tx).to.emit(tokenV2, "Transfer").withArgs(
-        userA.address,
-        ethers.constants.AddressZero,
-        amountToBurn
-      );
+      await expect(tx)
+        .to.emit(tokenV2, "Transfer")
+        .withArgs(userA.address, ethers.constants.AddressZero, amountToBurn);
 
       const userBalanceAfter = await tokenV2.balanceOf(userA.address);
       const contractBalanceAfter = await tokenV2.balanceOf(tokenV2.address);

--- a/test/zDAOTokenUpgrade.test.ts
+++ b/test/zDAOTokenUpgrade.test.ts
@@ -8,6 +8,7 @@ import {
   ZeroDAOTokenV2__factory,
   ERC20Mock__factory,
   ERC20Mock,
+  ZeroDAOToken__factory,
 } from "../typechain";
 import { deployFundTransfer } from "./helpers/deploy-fund-transfer";
 import { deployV2 } from "./helpers/deploy-v2";
@@ -22,7 +23,6 @@ import {
   DEFAULT_TEST_MINT_AMOUNT,
   DEFAULT_MOCK_TOKEN_DECIMALS,
   DEFAULT_WITHDRAW_AMOUNT,
-  DEFAULT_TOKEN_MINT_AMOUNT,
   DEFAULT_TRANSFER_AMOUNT
 } from "./helpers/constants";
 
@@ -90,6 +90,7 @@ describe("zDAO Token Upgrade", () => {
         tokenV2Factory
       ) as ZeroDAOTokenV2;
 
+
       expect(tokenV2.address).to.equal(tokenV1.address); // Same proxy address
     });
 
@@ -149,16 +150,14 @@ describe("zDAO Token Upgrade", () => {
       expect(userBBalance).to.equal(expectedMintAmount);
 
       // Test basic transfer functionality using userA's tokens
-      const transferAmount = ethers.utils.parseUnits(DEFAULT_TRANSFER_AMOUNT, 18);
-      const initialUserABalance = await tokenV2.balanceOf(userA.address);
-      const initialCreatorBalance = await tokenV2.balanceOf(creator.address);
+      const transferAmount = ethers.utils.parseUnits(DEFAULT_TRANSFER_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
 
       // Transfer from userA to creator
       await tokenV2.connect(userA).transfer(creator.address, transferAmount);
 
       // Verify balances updated correctly
-      expect(await tokenV2.balanceOf(userA.address)).to.equal(initialUserABalance.sub(transferAmount));
-      expect(await tokenV2.balanceOf(creator.address)).to.equal(initialCreatorBalance.add(transferAmount));
+      expect(await tokenV2.balanceOf(userA.address)).to.equal(userABalance.sub(transferAmount));
+      expect(await tokenV2.balanceOf(creator.address)).to.equal(creatorBalance.add(transferAmount));
 
       // Test snapshot functionality
       const snapshotTx = await tokenV2.connect(creator).snapshot();
@@ -166,7 +165,7 @@ describe("zDAO Token Upgrade", () => {
 
       // Verify snapshot captured the current balances
       const userABalanceAtSnapshot = await tokenV2.balanceOf(userA.address);
-      const snapshotId = 1; // First snapshot
+      const snapshotId = 1;
       const userASnapshotBalance = await tokenV2.balanceOfAt(userA.address, snapshotId);
       expect(userASnapshotBalance).to.equal(userABalanceAtSnapshot);
 
@@ -316,6 +315,70 @@ describe("zDAO Token Upgrade", () => {
         // Expected - function doesn't exist
         expect(error.message).to.include("burn is not a function");
       }
+    });
+
+    it("should verify `mint` and `burn` are no longer public functions", async () => {
+      const amount = hre.ethers.utils.parseEther("1");
+
+      // Confirm `mint` does not exist by on the contract itself
+      const mintData = new ZeroDAOToken__factory(creator).interface.encodeFunctionData(
+        "mint",
+        [
+          `${userA.address}`,
+          `${amount}`
+        ]
+      );
+
+      try {
+        await creator.sendTransaction({
+          to: tokenV2.address,
+          data: mintData,
+          value: 0
+        });
+      } catch (e) {
+        expect((e as Error).message.includes("function selector was not recognized"));
+      }
+
+      // Same for `burn`
+      const burnData = new ZeroDAOToken__factory(creator).interface.encodeFunctionData(
+        "burn",
+        [
+          `${userA.address}`,
+          `${amount}`
+        ]
+      );
+
+      try {
+        await creator.sendTransaction({
+          to: tokenV2.address,
+          data: burnData,
+          value: 0
+        });
+      } catch (e) {
+        expect((e as Error).message.includes("function selector was not recognized"));
+      }
+    });
+
+    it("burns when receives own token", async () => {
+      const userBalanceBefore = await tokenV2.balanceOf(userA.address);
+      const contractBalanceBefore = await tokenV2.balanceOf(tokenV2.address);
+
+      const amountToBurn = userBalanceBefore.div(5);
+      const tx = tokenV2.connect(userA).transfer(tokenV2.address, amountToBurn);
+
+      await expect(tx).to.emit(tokenV2, "Transfer").withArgs(
+        userA.address,
+        ethers.constants.AddressZero,
+        amountToBurn
+      );
+
+      const userBalanceAfter = await tokenV2.balanceOf(userA.address);
+      const contractBalanceAfter = await tokenV2.balanceOf(tokenV2.address);
+
+      expect(userBalanceAfter).to.eq(userBalanceBefore.sub(amountToBurn));
+
+      // No change, transfer was burnt not kept by contract
+      expect(contractBalanceAfter).to.eq(contractBalanceBefore);
     });
   });
 });

--- a/test/zDAOTokenUpgrade.test.ts
+++ b/test/zDAOTokenUpgrade.test.ts
@@ -28,8 +28,8 @@ import {
 
 describe("zDAO Token Upgrade", () => {
   let creator: SignerWithAddress;
-  let user1: SignerWithAddress;
-  let user2: SignerWithAddress;
+  let userA: SignerWithAddress;
+  let userB: SignerWithAddress;
 
   let tokenV1: ZeroDAOToken;
   let tokenV2: ZeroDAOTokenV2;
@@ -37,12 +37,10 @@ describe("zDAO Token Upgrade", () => {
   let preUpgradeState: ContractStorageData;
 
   before(async () => {
-    [creator, user1, user2] = await hre.ethers.getSigners();
+    [creator, userA, userB] = await hre.ethers.getSigners();
   });
 
   describe("Token Upgrade Flow", () => {
-
-
     it("should deploy and fund V1 token with mock ERC20", async () => {
       // Call deploy-fund-transfer helper
       tokenV1 = await deployFundTransfer(creator, creator.address);
@@ -61,20 +59,18 @@ describe("zDAO Token Upgrade", () => {
       const mintAmount = ethers.utils.parseUnits(DEFAULT_TEST_MINT_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
       await mockToken.mint(tokenV1.address, mintAmount);
 
+      // Fund users for later when public `mint` and `burn` functions are removed
+      await tokenV1.mint(userA.address, mintAmount);
+      await tokenV1.mint(userB.address, mintAmount);
+
       const balance = await mockToken.balanceOf(tokenV1.address);
       expect(balance).to.equal(mintAmount);
     });
 
-    it("should read state before upgrade", async () => {
+    it("should upgrade from V1 to V2", async () => {
       // Call readState helper to get state before upgrading
       preUpgradeState = await readState(creator, tokenV1.address);
 
-      expect(preUpgradeState).to.not.be.undefined;
-      expect(Array.isArray(preUpgradeState)).to.be.true;
-      expect(preUpgradeState.length).to.be.greaterThan(0);
-    });
-
-    it("should upgrade from V1 to V2", async () => {
       // Get the proxy admin and its owner
       const proxyAdmin = await hre.upgrades.admin.getInstance();
       const proxyAdminOwner = await proxyAdmin.owner();
@@ -105,23 +101,18 @@ describe("zDAO Token Upgrade", () => {
     });
 
     it("should test withdrawERC20 function and verify balances", async () => {
-
-      // Connect to the token as the owner
-      const tokenV2AsOwner = tokenV2.connect(creator);
-
       // Check initial balance of the contract
-      const initialBalance = await mockToken.balanceOf(tokenV2.address);
-      expect(initialBalance).to.be.gt(0);
+      const contractBalanceBefore = await mockToken.balanceOf(tokenV2.address);
 
       // Check initial balance of recipient (creator)
-      const recipientInitialBalance = await mockToken.balanceOf(creator.address);
+      const creatorBalance = await mockToken.balanceOf(creator.address);
 
       // Define withdrawal amount
       const withdrawAmount = ethers.utils.parseUnits(DEFAULT_WITHDRAW_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
-      expect(withdrawAmount).to.be.lte(initialBalance);
+      expect(withdrawAmount).to.be.lte(contractBalanceBefore);
 
       // Call withdrawERC20 function as the token owner
-      const tx = await tokenV2AsOwner.withdrawERC20(
+      const tx = await tokenV2.connect(creator).withdrawERC20(
         mockToken.address,
         creator.address,
         withdrawAmount
@@ -131,42 +122,200 @@ describe("zDAO Token Upgrade", () => {
       await tx.wait();
 
       // Check balances after withdrawal
-      const finalContractBalance = await mockToken.balanceOf(tokenV2.address);
-      const recipientFinalBalance = await mockToken.balanceOf(creator.address);
+      const contractBalanceFinal = await mockToken.balanceOf(tokenV2.address);
+      const creatorBalanceFinal = await mockToken.balanceOf(creator.address);
 
       // Verify the contract balance decreased by the withdrawal amount
-      expect(finalContractBalance).to.equal(initialBalance.sub(withdrawAmount));
+      expect(contractBalanceFinal).to.equal(contractBalanceBefore.sub(withdrawAmount));
 
       // Verify the recipient balance increased by the withdrawal amount
-      expect(recipientFinalBalance).to.equal(recipientInitialBalance.add(withdrawAmount));
+      expect(creatorBalanceFinal).to.equal(creatorBalance.add(withdrawAmount));
     });
 
     it("should verify token functionality is preserved after upgrade", async () => {
-      // Get the token owner (who can call mint)
-      const tokenOwnerAddress = await tokenV2.owner();
-      const accounts = await hre.ethers.getSigners();
-      const ownerSigner = accounts.find(account => account.address.toLowerCase() === tokenOwnerAddress.toLowerCase()) || creator;
+      // Verify basic token properties are preserved
+      expect(await tokenV2.name()).to.equal(DEFAULT_ZERO_TOKEN_NAME);
+      expect(await tokenV2.symbol()).to.equal(DEFAULT_ZERO_TOKEN_SYMBOL);
+      expect(await tokenV2.owner()).to.equal(creator.address);
 
-      // Connect to the token as the owner
-      const tokenV2AsOwner = tokenV2.connect(ownerSigner);
+      // Check balances - userA and userB should have tokens from the pre-upgrade minting
+      const creatorBalance = await tokenV2.balanceOf(creator.address);
+      const userABalance = await tokenV2.balanceOf(userA.address);
+      const userBBalance = await tokenV2.balanceOf(userB.address);
 
-      // Test that basic V1 functionality still works
-      const mintAmount = ethers.utils.parseEther(DEFAULT_TOKEN_MINT_AMOUNT);
+      // Verify that userA and userB have the expected token balances from pre-upgrade minting
+      const expectedMintAmount = ethers.utils.parseUnits(DEFAULT_TEST_MINT_AMOUNT, DEFAULT_MOCK_TOKEN_DECIMALS);
+      expect(userABalance).to.equal(expectedMintAmount);
+      expect(userBBalance).to.equal(expectedMintAmount);
 
-      await tokenV2AsOwner.mint(user1.address, mintAmount);
-      const balance = await tokenV2.balanceOf(user1.address);
-      expect(balance).to.equal(mintAmount);
+      // Test basic transfer functionality using userA's tokens
+      const transferAmount = ethers.utils.parseUnits(DEFAULT_TRANSFER_AMOUNT, 18);
+      const initialUserABalance = await tokenV2.balanceOf(userA.address);
+      const initialCreatorBalance = await tokenV2.balanceOf(creator.address);
 
-      // Test transfer functionality
-      const transferAmount = ethers.utils.parseEther(DEFAULT_TRANSFER_AMOUNT);
-      const tokenAsUser1 = tokenV2.connect(user1);
-      await tokenAsUser1.transfer(user2.address, transferAmount);
+      // Transfer from userA to creator
+      await tokenV2.connect(userA).transfer(creator.address, transferAmount);
 
-      const user1Balance = await tokenV2.balanceOf(user1.address);
-      const user2Balance = await tokenV2.balanceOf(user2.address);
+      // Verify balances updated correctly
+      expect(await tokenV2.balanceOf(userA.address)).to.equal(initialUserABalance.sub(transferAmount));
+      expect(await tokenV2.balanceOf(creator.address)).to.equal(initialCreatorBalance.add(transferAmount));
 
-      expect(user1Balance).to.equal(mintAmount.sub(transferAmount));
-      expect(user2Balance).to.equal(transferAmount);
+      // Test snapshot functionality
+      const snapshotTx = await tokenV2.connect(creator).snapshot();
+      await expect(snapshotTx).to.emit(tokenV2, "Snapshot");
+
+      // Verify snapshot captured the current balances
+      const userABalanceAtSnapshot = await tokenV2.balanceOf(userA.address);
+      const snapshotId = 1; // First snapshot
+      const userASnapshotBalance = await tokenV2.balanceOfAt(userA.address, snapshotId);
+      expect(userASnapshotBalance).to.equal(userABalanceAtSnapshot);
+
+      // Test snapshotter authorization functionality
+      await expect(tokenV2.connect(userA).snapshot()).to.be.revertedWith(
+        "zDAOToken: Not authorized to snapshot"
+      );
+
+      // Authorize userA to snapshot
+      const authTx = await tokenV2.connect(creator).authorizeSnapshotter(userA.address);
+      await expect(authTx).to.emit(tokenV2, "AuthorizedSnapshotter").withArgs(userA.address);
+
+      // Now userA should be able to snapshot
+      const userASnapshotTx = await tokenV2.connect(userA).snapshot();
+      await expect(userASnapshotTx).to.emit(tokenV2, "Snapshot");
+
+      // Deauthorize userA
+      const deauthTx = await tokenV2.connect(creator).deauthorizeSnapshotter(userA.address);
+      await expect(deauthTx).to.emit(tokenV2, "DeauthorizedSnapshotter").withArgs(userA.address);
+
+      // userA should no longer be able to snapshot
+      await expect(tokenV2.connect(userA).snapshot()).to.be.revertedWith(
+        "zDAOToken: Not authorized to snapshot"
+      );
+
+      // Test pause/unpause functionality
+      const pauseTx = await tokenV2.connect(creator).pause();
+      await expect(pauseTx).to.emit(tokenV2, "Paused");
+
+      // Transfers should be blocked when paused - test with userB's tokens
+      await expect(
+        tokenV2.connect(userB).transfer(creator.address, transferAmount)
+      ).to.be.revertedWith("ERC20Pausable: token transfer while paused");
+
+      // Unpause
+      const unpauseTx = await tokenV2.connect(creator).unpause();
+      await expect(unpauseTx).to.emit(tokenV2, "Unpaused");
+
+      // Test that transfers work again after unpausing
+      const userBBalanceBeforeTransfer = await tokenV2.balanceOf(userB.address);
+      const creatorBalanceBeforeTransfer = await tokenV2.balanceOf(creator.address);
+
+      await tokenV2.connect(userB).transfer(creator.address, transferAmount);
+
+      expect(await tokenV2.balanceOf(userB.address)).to.equal(userBBalanceBeforeTransfer.sub(transferAmount));
+      expect(await tokenV2.balanceOf(creator.address)).to.equal(creatorBalanceBeforeTransfer.add(transferAmount));
+
+      // Test bulk transfer functionality using creator's accumulated tokens
+      const currentCreatorBalance = await tokenV2.balanceOf(creator.address);
+      if (currentCreatorBalance.gt(ethers.utils.parseUnits("200", 18))) {
+        const bulkTransferAmount = ethers.utils.parseUnits("50", 18);
+        const recipients = [userA.address, userB.address];
+
+        const initialUserABalanceForBulk = await tokenV2.balanceOf(userA.address);
+        const initialUserBBalanceForBulk = await tokenV2.balanceOf(userB.address);
+
+        const bulkTx = await tokenV2.connect(creator).transferBulk(recipients, bulkTransferAmount);
+
+        // Verify events were emitted
+        await expect(bulkTx)
+          .to.emit(tokenV2, "Transfer")
+          .withArgs(creator.address, userA.address, bulkTransferAmount);
+        await expect(bulkTx)
+          .to.emit(tokenV2, "Transfer")
+          .withArgs(creator.address, userB.address, bulkTransferAmount);
+
+        // Verify balances
+        expect(await tokenV2.balanceOf(userA.address)).to.equal(initialUserABalanceForBulk.add(bulkTransferAmount));
+        expect(await tokenV2.balanceOf(userB.address)).to.equal(initialUserBBalanceForBulk.add(bulkTransferAmount));
+      }
+
+      // Test transferFromBulk functionality with approval
+      const userABalanceForBulkFrom = await tokenV2.balanceOf(userA.address);
+      if (userABalanceForBulkFrom.gt(ethers.utils.parseUnits("100", 18))) {
+        const bulkTransferAmount = ethers.utils.parseUnits("25", 18);
+        const recipients = [creator.address, userB.address];
+        const totalAmount = bulkTransferAmount.mul(recipients.length);
+
+        // userA approves userB to spend tokens
+        await tokenV2.connect(userA).approve(userB.address, totalAmount);
+
+        const initialCreatorBalanceForBulkFrom = await tokenV2.balanceOf(creator.address);
+        const initialUserBBalanceForBulkFrom = await tokenV2.balanceOf(userB.address);
+        const initialUserABalanceForBulkFrom = await tokenV2.balanceOf(userA.address);
+
+        // userB calls transferFromBulk to transfer userA's tokens
+        const bulkFromTx = await tokenV2.connect(userB).transferFromBulk(
+          userA.address,
+          recipients,
+          bulkTransferAmount
+        );
+
+        // Verify events were emitted
+        await expect(bulkFromTx)
+          .to.emit(tokenV2, "Transfer")
+          .withArgs(userA.address, creator.address, bulkTransferAmount);
+        await expect(bulkFromTx)
+          .to.emit(tokenV2, "Transfer")
+          .withArgs(userA.address, userB.address, bulkTransferAmount);
+
+        // Verify balances
+        expect(await tokenV2.balanceOf(userA.address)).to.equal(initialUserABalanceForBulkFrom.sub(totalAmount));
+        expect(await tokenV2.balanceOf(creator.address)).to.equal(initialCreatorBalanceForBulkFrom.add(bulkTransferAmount));
+        expect(await tokenV2.balanceOf(userB.address)).to.equal(initialUserBBalanceForBulkFrom.add(bulkTransferAmount));
+      }
+
+      // Test the new V2 burn-on-transfer-to-contract functionality
+      const userABalanceBeforeBurn = await tokenV2.balanceOf(userA.address);
+      const burnAmount = ethers.utils.parseUnits("10", 18);
+
+      if (userABalanceBeforeBurn.gt(burnAmount)) {
+        const totalSupplyBefore = await tokenV2.totalSupply();
+
+        // Transfer to the contract address should burn the tokens
+        await tokenV2.connect(userA).transfer(tokenV2.address, burnAmount);
+
+        const userABalanceAfterBurn = await tokenV2.balanceOf(userA.address);
+        const contractBalance = await tokenV2.balanceOf(tokenV2.address);
+        const totalSupplyAfter = await tokenV2.totalSupply();
+
+        // Verify tokens were burned (not transferred to contract)
+        expect(userABalanceAfterBurn).to.equal(userABalanceBeforeBurn.sub(burnAmount));
+        expect(contractBalance).to.equal(0); // Contract should have no tokens
+        expect(totalSupplyAfter).to.equal(totalSupplyBefore.sub(burnAmount)); // Total supply decreased
+      }
+
+      // Test that non-owners cannot call owner-only functions
+      await expect(tokenV2.connect(userA).pause()).to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(tokenV2.connect(userA).authorizeSnapshotter(userB.address)).to.be.revertedWith("Ownable: caller is not the owner");
+
+      // Verify that mint and burn functions no longer exist (should throw if called)
+      // Note: These functions were removed in V2, so calling them should fail
+      try {
+        // @ts-ignore - Intentionally calling removed function to verify it's gone
+        await tokenV2.mint(userA.address, 1000);
+        expect.fail("mint function should not exist in V2");
+      } catch (error: any) {
+        // Expected - function doesn't exist
+        expect(error.message).to.include("mint is not a function");
+      }
+
+      try {
+        // @ts-ignore - Intentionally calling removed function to verify it's gone
+        await tokenV2.burn(userA.address, 1000);
+        expect.fail("burn function should not exist in V2");
+      } catch (error: any) {
+        // Expected - function doesn't exist
+        expect(error.message).to.include("burn is not a function");
+      }
     });
   });
 });

--- a/test/zDaoToken.ts
+++ b/test/zDaoToken.ts
@@ -2,10 +2,7 @@ import { BigNumber } from "@ethersproject/bignumber";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
-import {
-  ZeroDAOToken,
-  ZeroDAOToken__factory,
-} from "../typechain";
+import { ZeroDAOToken, ZeroDAOToken__factory } from "../typechain";
 
 describe("zDAO Token", () => {
   let accounts: SignerWithAddress[];

--- a/test/zDaoTokenV2.ts
+++ b/test/zDaoTokenV2.ts
@@ -6,11 +6,11 @@ import {
   ERC20Mock__factory,
   ZeroDAOTokenV2__factory,
   ZeroDAOTokenV2,
+  ZeroDAOToken__factory,
+  ZeroDAOToken,
 } from "../typechain";
 
 import * as hre from "hardhat";
-import { compareStorageData, ContractStorageData, readContractStorage } from "../scripts/utils/storage-check";
-import { deployFundTransfer } from "./helpers/deploy-fund-transfer";
 
 /**
  * Unit test new functionality not already tested in the orginal contract
@@ -48,110 +48,173 @@ describe("zDAOTokenV2 Test", () => {
     await mockToken.mint(zeroDAOTokenV2.address, testTokenAmount);
   });
 
-  it("calls withdrawERC20 to withdraw a specific amount to an EOA", async () => {
-    const initialRecipientBalance = await mockToken.balanceOf(userA.address);
-    const initialContractBalance = await mockToken.balanceOf(zeroDAOTokenV2.address);
+  describe("#withdrawERC20", () => {
+    it("calls withdrawERC20 to withdraw a specific amount to an EOA", async () => {
+      const userBalanceBefore = await mockToken.balanceOf(userA.address);
+      const contractBalanceBefore = await mockToken.balanceOf(zeroDAOTokenV2.address);
 
-    // Call withdrawERC20 function - use creator since they own the contract
-    // Use exact amount the contract has on it as a parameter
-    const tx = zeroDAOTokenV2.connect(creator).withdrawERC20(
-      mockToken.address,
-      userA.address,
-      initialContractBalance
-    );
+      // Call withdrawERC20 function - use creator since they own the contract
+      // Use exact amount the contract has on it as a parameter
+      const tx = zeroDAOTokenV2.connect(creator).withdrawERC20(
+        mockToken.address,
+        userA.address,
+        contractBalanceBefore
+      );
 
-    // Verify the transaction emitted the correct event
-    await expect(tx)
-      .to.emit(zeroDAOTokenV2, "ERC20TokenWithdrawn")
-      .withArgs(mockToken.address, userA.address, testTokenAmount);
+      // Verify the transaction emitted the correct event
+      await expect(tx)
+        .to.emit(zeroDAOTokenV2, "ERC20TokenWithdrawn")
+        .withArgs(mockToken.address, userA.address, testTokenAmount);
 
-    // Check contract balance (should be 0)
-    const finalContractBalance = await mockToken.balanceOf(zeroDAOTokenV2.address);
-    expect(finalContractBalance).to.eq(initialContractBalance.sub(testTokenAmount));
+      // Check contract balance (should be 0)
+      const contractBalanceAfter = await mockToken.balanceOf(zeroDAOTokenV2.address);
+      expect(contractBalanceAfter).to.eq(contractBalanceBefore.sub(testTokenAmount));
 
-    // Check recipient balance (should have received the tokens)
-    const finalRecipientBalance = await mockToken.balanceOf(userA.address);
-    expect(finalRecipientBalance).to.eq(initialRecipientBalance.add(testTokenAmount));
-  });
+      // Check recipient balance (should have received the tokens)
+      const finalRecipientBalance = await mockToken.balanceOf(userA.address);
+      expect(finalRecipientBalance).to.eq(userBalanceBefore.add(testTokenAmount));
+    });
 
-  it("tests withdrawERC20 with amount 0 (withdraw all)", async () => {
-    // First, give the contract some more tokens
-    const additionalAmount = ethers.utils.parseUnits("100000", decimals);
-    await mockToken.connect(creator).mint(zeroDAOTokenV2.address, additionalAmount);
+    it("tests withdrawERC20 with amount 0 (withdraw all)", async () => {
+      // First, give the contract some more tokens
+      const additionalAmount = ethers.utils.parseUnits("100000", decimals);
+      await mockToken.connect(creator).mint(zeroDAOTokenV2.address, additionalAmount);
 
-    const contractBalanceBefore = await mockToken.balanceOf(zeroDAOTokenV2.address);
-    const userBalanceBefore = await mockToken.balanceOf(userB.address);
+      const contractBalanceBefore = await mockToken.balanceOf(zeroDAOTokenV2.address);
+      const userBalanceBefore = await mockToken.balanceOf(userB.address);
 
-    // Call withdrawERC20 with amount 0 (withdraw all)
-    const tx = zeroDAOTokenV2.connect(creator).withdrawERC20(
-      mockToken.address,
-      userB.address,
-      0
-    );
+      // Call withdrawERC20 with amount 0 (withdraw all)
+      const tx = zeroDAOTokenV2.connect(creator).withdrawERC20(
+        mockToken.address,
+        userB.address,
+        0
+      );
 
-    // Verify the transaction emitted the correct event with the full amount
-    await expect(tx)
-      .to.emit(zeroDAOTokenV2, "ERC20TokenWithdrawn")
-      .withArgs(mockToken.address, userB.address, additionalAmount);
+      // Verify the transaction emitted the correct event with the full amount
+      await expect(tx)
+        .to.emit(zeroDAOTokenV2, "ERC20TokenWithdrawn")
+        .withArgs(mockToken.address, userB.address, additionalAmount);
 
-    // Check final balances
-    const contractBalanceAfter = await mockToken.balanceOf(zeroDAOTokenV2.address);
-    const userBalanceAfter = await mockToken.balanceOf(userB.address);
+      // Check final balances
+      const contractBalanceAfter = await mockToken.balanceOf(zeroDAOTokenV2.address);
+      const userBalanceAfter = await mockToken.balanceOf(userB.address);
 
-    // Confirm it drained the contract
-    expect(contractBalanceAfter).to.eq(0);
-    expect(contractBalanceAfter).to.eq(contractBalanceBefore.sub(additionalAmount));
-    expect(userBalanceAfter).to.eq(userBalanceBefore.add(additionalAmount));
-  });
+      // Confirm it drained the contract
+      expect(contractBalanceAfter).to.eq(0);
+      expect(contractBalanceAfter).to.eq(contractBalanceBefore.sub(additionalAmount));
+      expect(userBalanceAfter).to.eq(userBalanceBefore.add(additionalAmount));
+    });
 
-  it("Fails when called by non-owner", async () => {
-    // Give the contract some tokens first
-    await mockToken.connect(creator).mint(zeroDAOTokenV2.address, testTokenAmount);
+    it("Fails when called by non-owner", async () => {
+      // Give the contract some tokens first
+      await mockToken.connect(creator).mint(zeroDAOTokenV2.address, testTokenAmount);
 
-    // Try to call withdrawERC20 from non-owner account (creator is not the owner, creator is)
-    await expect(
-      zeroDAOTokenV2.connect(userA).withdrawERC20(
+      // Try to call withdrawERC20 from non-owner account (creator is not the owner, creator is)
+      await expect(
+        zeroDAOTokenV2.connect(userA).withdrawERC20(
+          mockToken.address,
+          creator.address,
+          testTokenAmount
+        )
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("Fails when token or recipient address is zero", async () => {
+      // Test zero token address - use creator since they own the contract
+      await expect(
+        zeroDAOTokenV2.connect(creator).withdrawERC20(
+          ethers.constants.AddressZero,
+          userA.address,
+          testTokenAmount
+        )
+      ).to.be.revertedWith("zDAOToken: Token address cannot be zero");
+
+      // Test zero recipient address - use creator since they own the contract
+      await expect(
+        zeroDAOTokenV2.connect(creator).withdrawERC20(
+          mockToken.address,
+          ethers.constants.AddressZero,
+          testTokenAmount
+        )
+      ).to.be.revertedWith("zDAOToken: Recipient address cannot be zero");
+    });
+
+    it("Fails when contract has insufficient token balance", async () => {
+      // First, withdraw any remaining amount to ensure the following call fails correctly
+      await zeroDAOTokenV2.connect(creator).withdrawERC20(
         mockToken.address,
         creator.address,
-        testTokenAmount
-      )
-    ).to.be.revertedWith("Ownable: caller is not the owner");
+        0
+      );
+
+      await expect(
+        zeroDAOTokenV2.connect(creator).withdrawERC20(
+          mockToken.address,
+          userA.address,
+          testTokenAmount
+        )
+      ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
+    });
   });
 
-  it("Fails when token or recipient address is zero", async () => {
-    // Test zero token address - use creator since they own the contract
-    await expect(
-      zeroDAOTokenV2.connect(creator).withdrawERC20(
-        ethers.constants.AddressZero,
+  describe("#_transfer", () => {
+    let zeroDAOToken: ZeroDAOToken;
+    let zeroDAOTokenV2: ZeroDAOTokenV2;
+
+    before(async () => {
+      zeroDAOToken = await hre.upgrades.deployProxy(
+        new ZeroDAOToken__factory(creator),
+        [
+          "TEST WILD",
+          "tWILD"
+        ]
+      ) as ZeroDAOToken;
+
+      // Give balance to creator with public mint
+      await zeroDAOToken.connect(creator).mint(
         userA.address,
         testTokenAmount
-      )
-    ).to.be.revertedWith("zDAOToken: Token address cannot be zero");
+      );
 
-    // Test zero recipient address - use creator since they own the contract
-    await expect(
-      zeroDAOTokenV2.connect(creator).withdrawERC20(
-        mockToken.address,
-        ethers.constants.AddressZero,
-        testTokenAmount
-      )
-    ).to.be.revertedWith("zDAOToken: Recipient address cannot be zero");
-  });
+      // Then upgrade to have contract with internal burn on overridden `_transfer`
+      zeroDAOTokenV2 = await hre.upgrades.upgradeProxy(
+        zeroDAOToken.address,
+        new ZeroDAOTokenV2__factory(creator),
+      ) as ZeroDAOTokenV2;
+    });
 
-  it("Fails when contract has insufficient token balance", async () => {
-    // First, withdraw any remaining amount to ensure the following call fails correctly
-    await zeroDAOTokenV2.connect(creator).withdrawERC20(
-      mockToken.address,
-      creator.address,
-      0
-    );
+    it("does not burn tokens on transfer to non-contract addresses", async () => {
+      const userABalanceBefore = await zeroDAOTokenV2.balanceOf(userA.address);
+      const userBBalanceBefore = await zeroDAOTokenV2.balanceOf(userB.address);
 
-    await expect(
-      zeroDAOTokenV2.connect(creator).withdrawERC20(
-        mockToken.address,
-        userA.address,
-        testTokenAmount
-      )
-    ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
+      const tx = await zeroDAOTokenV2.connect(userA).transfer(userB.address, testTokenAmount);
+      await tx.wait();
+
+      const userABalanceAfter = await zeroDAOTokenV2.balanceOf(userA.address);
+      const userBBalanceAfter = await zeroDAOTokenV2.balanceOf(userB.address);
+
+      // Amount was transferred correctly, no burn took place
+      expect(userABalanceAfter).to.eq(userABalanceBefore.sub(testTokenAmount));
+      expect(userBBalanceAfter).to.eq(userBBalanceBefore.add(testTokenAmount));
+    });
+
+    it("burns tokens on transfer to contract", async () => {
+      const contractBalanceBefore = await zeroDAOTokenV2.balanceOf(userA.address);
+      const userBBalanceBefore = await zeroDAOTokenV2.balanceOf(userB.address);
+
+      // console.log("v1Address: ", zeroDAOToken.address);
+      // console.log("v2Address: ", zeroDAOTokenV2.address);
+      // console.log("userB: ", userB.address)
+      // Transfer tokens to contract directly
+      await zeroDAOTokenV2.connect(userB).transfer(zeroDAOTokenV2.address, testTokenAmount);
+
+      const contractBalanceAfter = await zeroDAOTokenV2.balanceOf(userA.address);
+      const userBBalanceAfter = await zeroDAOTokenV2.balanceOf(userB.address);
+
+      // Amount was not transferred to contract, it was burned
+      expect(contractBalanceAfter).to.eq(0);
+      expect(contractBalanceAfter).to.eq(contractBalanceBefore);
+      expect(userBBalanceAfter).to.eq(userBBalanceBefore.sub(testTokenAmount));
+    });
   });
 });

--- a/test/zDaoTokenV2.ts
+++ b/test/zDaoTokenV2.ts
@@ -2,8 +2,6 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import {
-  ZeroDAOToken,
-  ZeroDAOToken__factory,
   ERC20Mock,
   ERC20Mock__factory,
   ZeroDAOTokenV2__factory,
@@ -14,371 +12,146 @@ import * as hre from "hardhat";
 import { compareStorageData, ContractStorageData, readContractStorage } from "../scripts/utils/storage-check";
 import { deployFundTransfer } from "./helpers/deploy-fund-transfer";
 
-
-describe("zDAOToken => zDAOTokenV2 Upgrade Test", () => {
+/**
+ * Unit test new functionality not already tested in the orginal contract
+ */
+describe("zDAOTokenV2 Test", () => {
   let creator: SignerWithAddress;
 
-  let newOwner: SignerWithAddress;
-  let user1: SignerWithAddress;
-  let user2: SignerWithAddress;
+  let userA: SignerWithAddress;
+  let userB: SignerWithAddress;
 
-  let zeroDAOToken: ZeroDAOToken;
+  // let zeroDAOToken: ZeroDAOToken;
   let zeroDAOTokenV2: ZeroDAOTokenV2;
   let mockToken: ERC20Mock;
-  let preUpgradeState: ContractStorageData;
+
   // Update as needed for testing
   const decimals = 6;
   const testTokenAmount = ethers.utils.parseUnits("500000", decimals);
 
   before(async () => {
-    [creator, newOwner, user1, user2] = await ethers.getSigners();
+    [creator, userA, userB] = await ethers.getSigners();
+
+    zeroDAOTokenV2 = await hre.upgrades.deployProxy(
+      new ZeroDAOTokenV2__factory(creator),
+      [
+        "Test WILD",
+        "tWILD"
+      ]
+    ) as ZeroDAOTokenV2;
+
+    const mockTokenFactory = new ERC20Mock__factory(creator);
+    mockToken = await mockTokenFactory.deploy("Test Mock Token", "TMT");
+    await mockToken.deployed();
+
+    // Give test balance to contract
+    await mockToken.mint(zeroDAOTokenV2.address, testTokenAmount);
   });
 
-  describe("ZeroDAOToken to ZeroDAOTokenV2 upgrade test - mint function removal", () => {
-    it("Deploys original ZeroDAOToken contract", async () => {
-      // Deploy the original ZeroDAOToken using the original factory
-      // Use the `deployV1` Helper to that sets up the initial environment the same way it is used in scripts
-      // - Deploy ZeroDAOToken contract
-      // - Deploy an ERC20Mock contract, give funds to ZeroDAOToken
-      // - Transfer ownership to a given address
-      zeroDAOToken = await deployFundTransfer(creator, newOwner.address);
-    });
+  it("calls withdrawERC20 to withdraw a specific amount to an EOA", async () => {
+    const initialRecipientBalance = await mockToken.balanceOf(userA.address);
+    const initialContractBalance = await mockToken.balanceOf(zeroDAOTokenV2.address);
 
-    it("Deploys mock token and mints balance to deployed zeroDAOToken", async () => {
-      // Deploy ERC20Mock
-      const mockTokenFactory = new ERC20Mock__factory(creator);
-      mockToken = await mockTokenFactory.deploy("Test Mock Token", "TMT");
-      await mockToken.deployed();
+    // Call withdrawERC20 function - use creator since they own the contract
+    // Use exact amount the contract has on it as a parameter
+    const tx = zeroDAOTokenV2.connect(creator).withdrawERC20(
+      mockToken.address,
+      userA.address,
+      initialContractBalance
+    );
 
-      await mockToken.mint(zeroDAOToken.address, testTokenAmount);
+    // Verify the transaction emitted the correct event
+    await expect(tx)
+      .to.emit(zeroDAOTokenV2, "ERC20TokenWithdrawn")
+      .withArgs(mockToken.address, userA.address, testTokenAmount);
 
-      expect(await mockToken.balanceOf(zeroDAOToken.address)).to.eq(testTokenAmount);
-    });
+    // Check contract balance (should be 0)
+    const finalContractBalance = await mockToken.balanceOf(zeroDAOTokenV2.address);
+    expect(finalContractBalance).to.eq(initialContractBalance.sub(testTokenAmount));
 
-    it("Upgrades ZeroDAOToken to ZeroDAOTokenV2", async () => {
-      // Store pre-upgrade state
-      const preUpgradeName = await zeroDAOToken.name();
-      const preUpgradeSymbol = await zeroDAOToken.symbol();
-      const preUpgradeOwner = await zeroDAOToken.owner();
-      const preUpgradeTotalSupply = await zeroDAOToken.totalSupply();
-      const preUpgradeUser1Balance = await zeroDAOToken.balanceOf(newOwner.address);
-      const preUpgradeContractBalance = await mockToken.balanceOf(zeroDAOToken.address);
+    // Check recipient balance (should have received the tokens)
+    const finalRecipientBalance = await mockToken.balanceOf(userA.address);
+    expect(finalRecipientBalance).to.eq(initialRecipientBalance.add(testTokenAmount));
+  });
 
-      preUpgradeState = await readContractStorage(
-        new ZeroDAOToken__factory(creator),
-        zeroDAOToken
-      );
+  it("tests withdrawERC20 with amount 0 (withdraw all)", async () => {
+    // First, give the contract some more tokens
+    const additionalAmount = ethers.utils.parseUnits("100000", decimals);
+    await mockToken.connect(creator).mint(zeroDAOTokenV2.address, additionalAmount);
 
-      // Perform the upgrade - use newOwner since they own the proxy admin
-      zeroDAOTokenV2 = await hre.upgrades.upgradeProxy(
-        zeroDAOToken.address,
-        new ZeroDAOTokenV2__factory(newOwner)
-      ) as ZeroDAOTokenV2;
+    const contractBalanceBefore = await mockToken.balanceOf(zeroDAOTokenV2.address);
+    const userBalanceBefore = await mockToken.balanceOf(userB.address);
 
-      // Verify the upgrade was successful
-      expect(zeroDAOTokenV2.address).to.eq(zeroDAOToken.address);
+    // Call withdrawERC20 with amount 0 (withdraw all)
+    const tx = zeroDAOTokenV2.connect(creator).withdrawERC20(
+      mockToken.address,
+      userB.address,
+      0
+    );
 
-      // Verify state variables are preserved
-      expect(await zeroDAOTokenV2.name()).to.eq(preUpgradeName);
-      expect(await zeroDAOTokenV2.symbol()).to.eq(preUpgradeSymbol);
-      expect(await zeroDAOTokenV2.owner()).to.eq(preUpgradeOwner);
-      expect(await zeroDAOTokenV2.totalSupply()).to.eq(preUpgradeTotalSupply);
-      expect(await zeroDAOTokenV2.balanceOf(newOwner.address)).to.eq(preUpgradeUser1Balance);
-      expect(await mockToken.balanceOf(zeroDAOToken.address)).to.eq(preUpgradeContractBalance);
-    });
+    // Verify the transaction emitted the correct event with the full amount
+    await expect(tx)
+      .to.emit(zeroDAOTokenV2, "ERC20TokenWithdrawn")
+      .withArgs(mockToken.address, userB.address, additionalAmount);
 
-    it("calls withdrawERC20 to withdraw that balance amount to an EOA", async () => {
-      const initialRecipientBalance = await mockToken.balanceOf(user1.address);
-      const initialContractBalance = await mockToken.balanceOf(zeroDAOTokenV2.address);
+    // Check final balances
+    const contractBalanceAfter = await mockToken.balanceOf(zeroDAOTokenV2.address);
+    const userBalanceAfter = await mockToken.balanceOf(userB.address);
 
-      // Call withdrawERC20 function - use newOwner since they own the contract
-      const tx = await zeroDAOTokenV2.connect(newOwner).withdrawERC20(
+    // Confirm it drained the contract
+    expect(contractBalanceAfter).to.eq(0);
+    expect(contractBalanceAfter).to.eq(contractBalanceBefore.sub(additionalAmount));
+    expect(userBalanceAfter).to.eq(userBalanceBefore.add(additionalAmount));
+  });
+
+  it("Fails when called by non-owner", async () => {
+    // Give the contract some tokens first
+    await mockToken.connect(creator).mint(zeroDAOTokenV2.address, testTokenAmount);
+
+    // Try to call withdrawERC20 from non-owner account (creator is not the owner, creator is)
+    await expect(
+      zeroDAOTokenV2.connect(userA).withdrawERC20(
         mockToken.address,
-        user1.address,
+        creator.address,
         testTokenAmount
-      );
-
-      // Verify the transaction emitted the correct event
-      await expect(tx)
-        .to.emit(zeroDAOTokenV2, "ERC20TokenWithdrawn")
-        .withArgs(mockToken.address, user1.address, testTokenAmount);
-
-      // Check contract balance (should be 0)
-      const finalContractBalance = await mockToken.balanceOf(zeroDAOTokenV2.address);
-      expect(finalContractBalance).to.eq(initialContractBalance.sub(testTokenAmount));
-
-      // Check recipient balance (should have received the tokens)
-      const finalRecipientBalance = await mockToken.balanceOf(user1.address);
-      expect(finalRecipientBalance).to.eq(initialRecipientBalance.add(testTokenAmount));
-    });
-
-    it("tests withdrawERC20 with amount 0 (withdraw all)", async () => {
-      // First, give the contract some more tokens
-      const additionalAmount = ethers.utils.parseUnits("100000", decimals);
-      await mockToken.connect(creator).mint(zeroDAOTokenV2.address, additionalAmount);
-
-      const initialRecipientBalance = await mockToken.balanceOf(user2.address);
-
-      // Call withdrawERC20 with amount 0 (should withdraw all) - use newOwner since they own the contract
-      const tx = zeroDAOTokenV2.connect(newOwner).withdrawERC20(
-        mockToken.address,
-        user2.address,
-        0 // This should withdraw total contract balance of `token` given
-      );
-
-      // Verify the transaction emitted the correct event with the full amount
-      expect(await tx)
-        .to.emit(zeroDAOTokenV2, "ERC20TokenWithdrawn")
-        .withArgs(mockToken.address, user2.address, additionalAmount);
-
-      // Check final balances
-      const finalContractBalance = await mockToken.balanceOf(zeroDAOTokenV2.address);
-      const finalRecipientBalance = await mockToken.balanceOf(user2.address);
-
-      expect(finalContractBalance).to.eq(0);
-      expect(finalRecipientBalance).to.eq(initialRecipientBalance.add(additionalAmount));
-    });
-
-    it("Fails when called by non-owner", async () => {
-      // Give the contract some tokens first
-      const testAmount = ethers.utils.parseUnits("1000", decimals);
-      await mockToken.connect(creator).mint(zeroDAOTokenV2.address, testAmount);
-
-      // Try to call withdrawERC20 from non-owner account (creator is not the owner, newOwner is)
-      await expect(
-        zeroDAOTokenV2.connect(creator).withdrawERC20(
-          mockToken.address,
-          creator.address,
-          testAmount
-        )
-      ).to.be.revertedWith("Ownable: caller is not the owner");
-    });
-
-    it("Fails when token or recipient address is zero", async () => {
-      const testAmount = ethers.utils.parseUnits("1000", decimals);
-
-      // Test zero token address - use newOwner since they own the contract
-      await expect(
-        zeroDAOTokenV2.connect(newOwner).withdrawERC20(
-          ethers.constants.AddressZero,
-          user1.address,
-          testAmount
-        )
-      ).to.be.revertedWith("zDAOToken: Token address cannot be zero");
-
-      // Test zero recipient address - use newOwner since they own the contract
-      await expect(
-        zeroDAOTokenV2.connect(newOwner).withdrawERC20(
-          mockToken.address,
-          ethers.constants.AddressZero,
-          testAmount
-        )
-      ).to.be.revertedWith("zDAOToken: Recipient address cannot be zero");
-    });
-
-    it("Fails when contract has insufficient token balance", async () => {
-      // Test insufficient balance (contract has 1000, trying to withdraw 2000) - use newOwner since they own the contract
-      await expect(
-        zeroDAOTokenV2.connect(newOwner).withdrawERC20(
-          mockToken.address,
-          user1.address,
-          ethers.utils.parseUnits("2000", decimals)
-        )
-      ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
-    });
-
-    it("Post-upgrade base state should match state pre-upgrade", async () => {
-      // Verify storage layout is compatible
-      const postUpgradeState = await readContractStorage(
-        new ZeroDAOTokenV2__factory(creator),
-        zeroDAOTokenV2
-      );
-
-      compareStorageData(
-        preUpgradeState,
-        postUpgradeState,
-      );
-    });
+      )
+    ).to.be.revertedWith("Ownable: caller is not the owner");
   });
 
-  describe("post-upgrade core functionality", () => {
-    it("owner can mint; standard transfer works", async () => {
-      expect(await zeroDAOTokenV2.owner()).to.eq(newOwner.address);
-      expect(zeroDAOTokenV2.address).to.eq(zeroDAOToken.address);
+  it("Fails when token or recipient address is zero", async () => {
+    // Test zero token address - use creator since they own the contract
+    await expect(
+      zeroDAOTokenV2.connect(creator).withdrawERC20(
+        ethers.constants.AddressZero,
+        userA.address,
+        testTokenAmount
+      )
+    ).to.be.revertedWith("zDAOToken: Token address cannot be zero");
 
-      const mintCreator = ethers.utils.parseEther("1000");
-      const mintUser1 = ethers.utils.parseEther("100");
+    // Test zero recipient address - use creator since they own the contract
+    await expect(
+      zeroDAOTokenV2.connect(creator).withdrawERC20(
+        mockToken.address,
+        ethers.constants.AddressZero,
+        testTokenAmount
+      )
+    ).to.be.revertedWith("zDAOToken: Recipient address cannot be zero");
+  });
 
-      await expect(
-        zeroDAOTokenV2.connect(creator).mint(creator.address, mintUser1)
-      ).to.be.revertedWith("Ownable: caller is not the owner");
+  it("Fails when contract has insufficient token balance", async () => {
+    // First, withdraw any remaining amount to ensure the following call fails correctly
+    await zeroDAOTokenV2.connect(creator).withdrawERC20(
+      mockToken.address,
+      creator.address,
+      0
+    );
 
-      const creatorBalBefore = await zeroDAOTokenV2.balanceOf(creator.address);
-      const user1BalBefore = await zeroDAOTokenV2.balanceOf(newOwner.address);
-      const supplyBefore = await zeroDAOTokenV2.totalSupply();
-
-      await zeroDAOTokenV2.connect(newOwner).mint(creator.address, mintCreator);
-      await zeroDAOTokenV2.connect(newOwner).mint(newOwner.address, mintUser1);
-
-      expect(await zeroDAOTokenV2.balanceOf(creator.address)).to.eq(creatorBalBefore.add(mintCreator));
-      expect(await zeroDAOTokenV2.balanceOf(newOwner.address)).to.eq(user1BalBefore.add(mintUser1));
-      expect(await zeroDAOTokenV2.totalSupply()).to.eq(supplyBefore.add(mintCreator).add(mintUser1));
-
-      const transferAmt = ethers.utils.parseEther("10");
-      const creatorBalBeforeTransfer = await zeroDAOTokenV2.balanceOf(creator.address);
-      const user1BalBeforeTransfer = await zeroDAOTokenV2.balanceOf(newOwner.address);
-
-      await zeroDAOTokenV2.connect(creator).transfer(newOwner.address, transferAmt);
-
-      expect(await zeroDAOTokenV2.balanceOf(creator.address)).to.eq(creatorBalBeforeTransfer.sub(transferAmt));
-      expect(await zeroDAOTokenV2.balanceOf(newOwner.address)).to.eq(user1BalBeforeTransfer.add(transferAmt));
-    });
-
-    it("approve and transferFrom update balances and allowance", async () => {
-      const approveAmt = ethers.utils.parseEther("50");
-      await zeroDAOTokenV2.connect(creator).approve(user1.address, approveAmt);
-      expect(await zeroDAOTokenV2.allowance(creator.address, user1.address)).to.eq(approveAmt);
-
-      const tfAmt = ethers.utils.parseEther("20");
-      const creatorBalBefore = await zeroDAOTokenV2.balanceOf(creator.address);
-      const user3BalBefore = await zeroDAOTokenV2.balanceOf(user2.address);
-      const allowanceBefore = await zeroDAOTokenV2.allowance(creator.address, user1.address);
-
-      await zeroDAOTokenV2.connect(user1).transferFrom(creator.address, user2.address, tfAmt);
-
-      expect(await zeroDAOTokenV2.balanceOf(creator.address)).to.eq(creatorBalBefore.sub(tfAmt));
-      expect(await zeroDAOTokenV2.balanceOf(user2.address)).to.eq(user3BalBefore.add(tfAmt));
-      expect(await zeroDAOTokenV2.allowance(creator.address, user1.address)).to.eq(allowanceBefore.sub(tfAmt));
-    });
-
-    it("snapshot authorization and events work", async () => {
-      // Owner can snapshot
-      const nextId = await zeroDAOTokenV2.connect(newOwner).callStatic.snapshot();
-      await expect(zeroDAOTokenV2.connect(newOwner).snapshot()).to.not.be.reverted;
-      const expectedNext = nextId.add(1);
-      expect(await zeroDAOTokenV2.connect(newOwner).callStatic.snapshot()).to.eq(expectedNext);
-
-      // Non-owner unauthorized by default
-      await expect(zeroDAOTokenV2.connect(creator).snapshot()).to.be.revertedWith("zDAOToken: Not authorized to snapshot");
-
-      // Authorize creator
-      await expect(zeroDAOTokenV2.connect(newOwner).authorizeSnapshotter(creator.address))
-        .to.emit(zeroDAOTokenV2, "AuthorizedSnapshotter")
-        .withArgs(creator.address);
-
-      // Now creator can snapshot
-      await expect(zeroDAOTokenV2.connect(creator).snapshot()).to.not.be.reverted;
-
-      // Deauthorize and ensure it reverts again
-      await expect(zeroDAOTokenV2.connect(newOwner).deauthorizeSnapshotter(creator.address))
-        .to.emit(zeroDAOTokenV2, "DeauthorizedSnapshotter")
-        .withArgs(creator.address);
-
-      await expect(zeroDAOTokenV2.connect(creator).snapshot()).to.be.revertedWith("zDAOToken: Not authorized to snapshot");
-    });
-
-    it("pause/unpause gates token operations", async () => {
-      await zeroDAOTokenV2.connect(newOwner).pause();
-
-      await expect(
-        zeroDAOTokenV2.connect(creator).transfer(newOwner.address, ethers.utils.parseEther("1"))
-      ).to.be.revertedWith("ERC20Pausable: token transfer while paused");
-
-      await expect(
-        zeroDAOTokenV2.connect(newOwner).mint(creator.address, ethers.utils.parseEther("1"))
-      ).to.be.revertedWith("ERC20Pausable: token transfer while paused");
-
-      await zeroDAOTokenV2.connect(newOwner).unpause();
-
-      await expect(
-        zeroDAOTokenV2.connect(creator).transfer(newOwner.address, ethers.utils.parseEther("1"))
-      ).to.not.be.reverted;
-    });
-
-    it("transferBulk distributes to multiple recipients and validates inputs", async () => {
-      const recipients = [user1.address, user2.address];
-      const per = ethers.utils.parseEther("5");
-      const total = per.mul(recipients.length);
-
-      // Ensure creator has enough funds for this test
-      const creatorBal = await zeroDAOTokenV2.balanceOf(creator.address);
-      if (creatorBal.lt(total)) {
-        await zeroDAOTokenV2.connect(creator).mint(creator.address, total.sub(creatorBal));
-      }
-
-      const creatorBefore = await zeroDAOTokenV2.balanceOf(creator.address);
-      const user2Before = await zeroDAOTokenV2.balanceOf(user1.address);
-      const user3Before = await zeroDAOTokenV2.balanceOf(user2.address);
-
-      await zeroDAOTokenV2.connect(creator).transferBulk(recipients, per);
-
-      expect(await zeroDAOTokenV2.balanceOf(creator.address)).to.eq(creatorBefore.sub(total));
-      expect(await zeroDAOTokenV2.balanceOf(user1.address)).to.eq(user2Before.add(per));
-      expect(await zeroDAOTokenV2.balanceOf(user2.address)).to.eq(user3Before.add(per));
-
-      // Zero address recipient should revert
-      await expect(
-        zeroDAOTokenV2.connect(creator).transferBulk([ethers.constants.AddressZero], per)
-      ).to.be.revertedWith("ERC20: transfer to the zero address");
-
-      // Insufficient balance should revert
-      const tooBig = ethers.utils.parseEther("1000000000");
-      await expect(
-        zeroDAOTokenV2.connect(newOwner).transferBulk([user1.address], tooBig)
-      ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
-    });
-
-    it("transferFromBulk uses allowance and updates balances and allowance", async () => {
-      const recipients = [user1.address, user2.address, newOwner.address];
-      const per = ethers.utils.parseEther("2");
-      const total = per.mul(recipients.length);
-
-      // Ensure creator has enough and approve user1 to spend
-      const creatorBal = await zeroDAOTokenV2.balanceOf(creator.address);
-      if (creatorBal.lt(total)) {
-        await zeroDAOTokenV2.connect(creator).mint(creator.address, total.sub(creatorBal));
-      }
-
-      await expect(
-        zeroDAOTokenV2.connect(newOwner).transferFromBulk(creator.address, recipients, per)
-      ).to.be.revertedWith("ERC20: transfer total exceeds allowance");
-
-      await zeroDAOTokenV2.connect(creator).approve(newOwner.address, total);
-
-      const creatorBefore = await zeroDAOTokenV2.balanceOf(creator.address);
-      const allowancesBefore = await zeroDAOTokenV2.allowance(creator.address, newOwner.address);
-      const user1Before = await zeroDAOTokenV2.balanceOf(newOwner.address);
-      const user2Before = await zeroDAOTokenV2.balanceOf(user1.address);
-      const user3Before = await zeroDAOTokenV2.balanceOf(user2.address);
-
-      await zeroDAOTokenV2.connect(newOwner).transferFromBulk(creator.address, recipients, per);
-
-      expect(await zeroDAOTokenV2.balanceOf(creator.address)).to.eq(creatorBefore.sub(total));
-      expect(await zeroDAOTokenV2.balanceOf(newOwner.address)).to.eq(user1Before.add(per));
-      expect(await zeroDAOTokenV2.balanceOf(user1.address)).to.eq(user2Before.add(per));
-      expect(await zeroDAOTokenV2.balanceOf(user2.address)).to.eq(user3Before.add(per));
-      expect(await zeroDAOTokenV2.allowance(creator.address, newOwner.address)).to.eq(allowancesBefore.sub(total));
-    });
-
-    it("owner burn reduces holder balance and total supply", async () => {
-      // Ensure user1 has enough to burn
-      const burnAmt = ethers.utils.parseEther("10");
-      const user1Bal = await zeroDAOTokenV2.balanceOf(newOwner.address);
-      if (user1Bal.lt(burnAmt)) {
-        await zeroDAOTokenV2.connect(newOwner).mint(newOwner.address, burnAmt.sub(user1Bal));
-      }
-
-      await expect(zeroDAOTokenV2.connect(creator).burn(newOwner.address, burnAmt)).to.be.revertedWith(
-        "Ownable: caller is not the owner"
-      );
-
-      const user1Before = await zeroDAOTokenV2.balanceOf(newOwner.address);
-      const supplyBefore = await zeroDAOTokenV2.totalSupply();
-
-      await zeroDAOTokenV2.connect(newOwner).burn(newOwner.address, burnAmt);
-
-      expect(await zeroDAOTokenV2.balanceOf(newOwner.address)).to.eq(user1Before.sub(burnAmt));
-      expect(await zeroDAOTokenV2.totalSupply()).to.eq(supplyBefore.sub(burnAmt));
-    });
+    await expect(
+      zeroDAOTokenV2.connect(creator).withdrawERC20(
+        mockToken.address,
+        userA.address,
+        testTokenAmount
+      )
+    ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
   });
 });

--- a/test/zDaoTokenV2.ts
+++ b/test/zDaoTokenV2.ts
@@ -32,13 +32,10 @@ describe("zDAOTokenV2 Test", () => {
   before(async () => {
     [creator, userA, userB] = await ethers.getSigners();
 
-    zeroDAOTokenV2 = await hre.upgrades.deployProxy(
+    zeroDAOTokenV2 = (await hre.upgrades.deployProxy(
       new ZeroDAOTokenV2__factory(creator),
-      [
-        "Test WILD",
-        "tWILD"
-      ]
-    ) as ZeroDAOTokenV2;
+      ["Test WILD", "tWILD"]
+    )) as ZeroDAOTokenV2;
 
     const mockTokenFactory = new ERC20Mock__factory(creator);
     mockToken = await mockTokenFactory.deploy("Test Mock Token", "TMT");
@@ -51,15 +48,15 @@ describe("zDAOTokenV2 Test", () => {
   describe("#withdrawERC20", () => {
     it("calls withdrawERC20 to withdraw a specific amount to an EOA", async () => {
       const userBalanceBefore = await mockToken.balanceOf(userA.address);
-      const contractBalanceBefore = await mockToken.balanceOf(zeroDAOTokenV2.address);
+      const contractBalanceBefore = await mockToken.balanceOf(
+        zeroDAOTokenV2.address
+      );
 
       // Call withdrawERC20 function - use creator since they own the contract
       // Use exact amount the contract has on it as a parameter
-      const tx = zeroDAOTokenV2.connect(creator).withdrawERC20(
-        mockToken.address,
-        userA.address,
-        contractBalanceBefore
-      );
+      const tx = zeroDAOTokenV2
+        .connect(creator)
+        .withdrawERC20(mockToken.address, userA.address, contractBalanceBefore);
 
       // Verify the transaction emitted the correct event
       await expect(tx)
@@ -67,28 +64,36 @@ describe("zDAOTokenV2 Test", () => {
         .withArgs(mockToken.address, userA.address, testTokenAmount);
 
       // Check contract balance (should be 0)
-      const contractBalanceAfter = await mockToken.balanceOf(zeroDAOTokenV2.address);
-      expect(contractBalanceAfter).to.eq(contractBalanceBefore.sub(testTokenAmount));
+      const contractBalanceAfter = await mockToken.balanceOf(
+        zeroDAOTokenV2.address
+      );
+      expect(contractBalanceAfter).to.eq(
+        contractBalanceBefore.sub(testTokenAmount)
+      );
 
       // Check recipient balance (should have received the tokens)
       const finalRecipientBalance = await mockToken.balanceOf(userA.address);
-      expect(finalRecipientBalance).to.eq(userBalanceBefore.add(testTokenAmount));
+      expect(finalRecipientBalance).to.eq(
+        userBalanceBefore.add(testTokenAmount)
+      );
     });
 
     it("tests withdrawERC20 with amount 0 (withdraw all)", async () => {
       // First, give the contract some more tokens
       const additionalAmount = ethers.utils.parseUnits("100000", decimals);
-      await mockToken.connect(creator).mint(zeroDAOTokenV2.address, additionalAmount);
+      await mockToken
+        .connect(creator)
+        .mint(zeroDAOTokenV2.address, additionalAmount);
 
-      const contractBalanceBefore = await mockToken.balanceOf(zeroDAOTokenV2.address);
+      const contractBalanceBefore = await mockToken.balanceOf(
+        zeroDAOTokenV2.address
+      );
       const userBalanceBefore = await mockToken.balanceOf(userB.address);
 
       // Call withdrawERC20 with amount 0 (withdraw all)
-      const tx = zeroDAOTokenV2.connect(creator).withdrawERC20(
-        mockToken.address,
-        userB.address,
-        0
-      );
+      const tx = zeroDAOTokenV2
+        .connect(creator)
+        .withdrawERC20(mockToken.address, userB.address, 0);
 
       // Verify the transaction emitted the correct event with the full amount
       await expect(tx)
@@ -96,63 +101,67 @@ describe("zDAOTokenV2 Test", () => {
         .withArgs(mockToken.address, userB.address, additionalAmount);
 
       // Check final balances
-      const contractBalanceAfter = await mockToken.balanceOf(zeroDAOTokenV2.address);
+      const contractBalanceAfter = await mockToken.balanceOf(
+        zeroDAOTokenV2.address
+      );
       const userBalanceAfter = await mockToken.balanceOf(userB.address);
 
       // Confirm it drained the contract
       expect(contractBalanceAfter).to.eq(0);
-      expect(contractBalanceAfter).to.eq(contractBalanceBefore.sub(additionalAmount));
+      expect(contractBalanceAfter).to.eq(
+        contractBalanceBefore.sub(additionalAmount)
+      );
       expect(userBalanceAfter).to.eq(userBalanceBefore.add(additionalAmount));
     });
 
     it("Fails when called by non-owner", async () => {
       // Give the contract some tokens first
-      await mockToken.connect(creator).mint(zeroDAOTokenV2.address, testTokenAmount);
+      await mockToken
+        .connect(creator)
+        .mint(zeroDAOTokenV2.address, testTokenAmount);
 
       // Try to call withdrawERC20 from non-owner account (creator is not the owner, creator is)
       await expect(
-        zeroDAOTokenV2.connect(userA).withdrawERC20(
-          mockToken.address,
-          creator.address,
-          testTokenAmount
-        )
+        zeroDAOTokenV2
+          .connect(userA)
+          .withdrawERC20(mockToken.address, creator.address, testTokenAmount)
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
     it("Fails when token or recipient address is zero", async () => {
       // Test zero token address - use creator since they own the contract
       await expect(
-        zeroDAOTokenV2.connect(creator).withdrawERC20(
-          ethers.constants.AddressZero,
-          userA.address,
-          testTokenAmount
-        )
+        zeroDAOTokenV2
+          .connect(creator)
+          .withdrawERC20(
+            ethers.constants.AddressZero,
+            userA.address,
+            testTokenAmount
+          )
       ).to.be.revertedWith("zDAOToken: Token address cannot be zero");
 
       // Test zero recipient address - use creator since they own the contract
       await expect(
-        zeroDAOTokenV2.connect(creator).withdrawERC20(
-          mockToken.address,
-          ethers.constants.AddressZero,
-          testTokenAmount
-        )
+        zeroDAOTokenV2
+          .connect(creator)
+          .withdrawERC20(
+            mockToken.address,
+            ethers.constants.AddressZero,
+            testTokenAmount
+          )
       ).to.be.revertedWith("zDAOToken: Recipient address cannot be zero");
     });
 
     it("Fails when contract has insufficient token balance", async () => {
       // First, withdraw any remaining amount to ensure the following call fails correctly
-      await zeroDAOTokenV2.connect(creator).withdrawERC20(
-        mockToken.address,
-        creator.address,
-        0
-      );
+      await zeroDAOTokenV2
+        .connect(creator)
+        .withdrawERC20(mockToken.address, creator.address, 0);
 
       await expect(
-        zeroDAOTokenV2.connect(creator).withdrawERC20(
-          mockToken.address,
-          userA.address,
-          testTokenAmount
-        )
+        zeroDAOTokenV2
+          .connect(creator)
+          .withdrawERC20(mockToken.address, userA.address, testTokenAmount)
       ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
     });
   });
@@ -162,32 +171,28 @@ describe("zDAOTokenV2 Test", () => {
     let zeroDAOTokenV2: ZeroDAOTokenV2;
 
     before(async () => {
-      zeroDAOToken = await hre.upgrades.deployProxy(
+      zeroDAOToken = (await hre.upgrades.deployProxy(
         new ZeroDAOToken__factory(creator),
-        [
-          "TEST WILD",
-          "tWILD"
-        ]
-      ) as ZeroDAOToken;
+        ["TEST WILD", "tWILD"]
+      )) as ZeroDAOToken;
 
       // Give balance to creator with public mint
-      await zeroDAOToken.connect(creator).mint(
-        userA.address,
-        testTokenAmount
-      );
+      await zeroDAOToken.connect(creator).mint(userA.address, testTokenAmount);
 
       // Then upgrade to have contract with internal burn on overridden `_transfer`
-      zeroDAOTokenV2 = await hre.upgrades.upgradeProxy(
+      zeroDAOTokenV2 = (await hre.upgrades.upgradeProxy(
         zeroDAOToken.address,
-        new ZeroDAOTokenV2__factory(creator),
-      ) as ZeroDAOTokenV2;
+        new ZeroDAOTokenV2__factory(creator)
+      )) as ZeroDAOTokenV2;
     });
 
     it("does not burn tokens on transfer to non-contract addresses", async () => {
       const userABalanceBefore = await zeroDAOTokenV2.balanceOf(userA.address);
       const userBBalanceBefore = await zeroDAOTokenV2.balanceOf(userB.address);
 
-      const tx = await zeroDAOTokenV2.connect(userA).transfer(userB.address, testTokenAmount);
+      const tx = await zeroDAOTokenV2
+        .connect(userA)
+        .transfer(userB.address, testTokenAmount);
       await tx.wait();
 
       const userABalanceAfter = await zeroDAOTokenV2.balanceOf(userA.address);
@@ -199,16 +204,22 @@ describe("zDAOTokenV2 Test", () => {
     });
 
     it("burns tokens on transfer to contract", async () => {
-      const contractBalanceBefore = await zeroDAOTokenV2.balanceOf(userA.address);
+      const contractBalanceBefore = await zeroDAOTokenV2.balanceOf(
+        userA.address
+      );
       const userBBalanceBefore = await zeroDAOTokenV2.balanceOf(userB.address);
 
       // console.log("v1Address: ", zeroDAOToken.address);
       // console.log("v2Address: ", zeroDAOTokenV2.address);
       // console.log("userB: ", userB.address)
       // Transfer tokens to contract directly
-      await zeroDAOTokenV2.connect(userB).transfer(zeroDAOTokenV2.address, testTokenAmount);
+      await zeroDAOTokenV2
+        .connect(userB)
+        .transfer(zeroDAOTokenV2.address, testTokenAmount);
 
-      const contractBalanceAfter = await zeroDAOTokenV2.balanceOf(userA.address);
+      const contractBalanceAfter = await zeroDAOTokenV2.balanceOf(
+        userA.address
+      );
       const userBBalanceAfter = await zeroDAOTokenV2.balanceOf(userB.address);
 
       // Amount was not transferred to contract, it was burned


### PR DESCRIPTION
Change the upgrade from v1 to v2 to also include:

1. Removal of public `mint` and `burn` functions
2. Override of internal `_transfer` to call `_burn` when the contract's own token is sent to itself

This is on top of the already added function `withdrawERC20` to access previously stuck funds